### PR TITLE
Add support for task status

### DIFF
--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -23,6 +23,9 @@ class TaskStatus(Flag):
     def is_terminal(self) -> bool:
         return bool(self & TaskStatus.TERMINAL)
 
+    def __str__(self) -> str:
+        return str(self.name).lower()
+
 
 STATUS_FILE_MAP = {
     TaskStatus.SUCCESS: "status-success",

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -25,7 +25,7 @@ class TaskStatus(Flag):
 
 
 STATUS_FILE_MAP = {
-    TaskStatus.SUCCESS:  "status-success",
+    TaskStatus.SUCCESS: "status-success",
     TaskStatus.FAILURE: "status-failure",
     TaskStatus.CANCELLED: "status-cancelled",
     TaskStatus.RUNNING: "status-running",

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -1,7 +1,51 @@
 import pickle
 from dataclasses import dataclass
+from enum import Flag, auto
 
 from hipercow.root import Root
+from hipercow.util import file_create
+
+
+class TaskStatus(Flag):
+    CREATED = auto()
+    SUBMITTED = auto()
+    RUNNING = auto()
+    SUCCESS = auto()
+    FAILURE = auto()
+    CANCELLED = auto()
+    MISSING = auto()
+    TERMINAL = SUCCESS | FAILURE | CANCELLED
+    RUNNABLE = CREATED | SUBMITTED
+
+    def is_runnable(self) -> bool:
+        return bool(self & TaskStatus.RUNNABLE)
+
+    def is_terminal(self) -> bool:
+        return bool(self & TaskStatus.TERMINAL)
+
+
+STATUS_FILE_MAP = {
+    TaskStatus.SUCCESS:  "status-success",
+    TaskStatus.FAILURE: "status-failure",
+    TaskStatus.CANCELLED: "status-cancelled",
+    TaskStatus.RUNNING: "status-running",
+    TaskStatus.SUBMITTED: "status-submitted",
+}
+
+
+def task_status(root: Root, task_id: str) -> TaskStatus:
+    # check_task_id(task_id)
+    path = root.path / "tasks" / task_id
+    if not path.exists():
+        return TaskStatus.MISSING
+    for v, p in STATUS_FILE_MAP.items():
+        if (path / p).exists():
+            return v
+    return TaskStatus.CREATED
+
+
+def set_task_status(root: Root, task_id: str, status: TaskStatus):
+    file_create(root.path / "tasks" / task_id / STATUS_FILE_MAP[status])
 
 
 @dataclass
@@ -21,12 +65,12 @@ class TaskData:
 
 
 def task_data_write(root: Root, data: TaskData) -> None:
-    path_task_dir = root.path / "tasks"
+    path_task_dir = root.path / "tasks" / data.task_id
     path_task_dir.mkdir(parents=True, exist_ok=True)
-    with open(path_task_dir / data.task_id, "wb") as f:
+    with open(path_task_dir / "data", "wb") as f:
         pickle.dump(data, f)
 
 
 def task_data_read(root: Root, task_id: str) -> TaskData:
-    with open(root.path / "tasks" / task_id, "rb") as f:
+    with open(root.path / "tasks" / task_id / "data", "rb") as f:
         return pickle.load(f)

--- a/src/hipercow/util.py
+++ b/src/hipercow/util.py
@@ -30,3 +30,7 @@ def transient_working_directory(path):
     finally:
         if path is not None:
             os.chdir(origin)
+
+
+def file_create(path: str | Path) -> None:
+    Path(path).open("a").close()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -11,7 +11,7 @@ def test_create_simple_task(tmp_path):
     with transient_working_directory(tmp_path):
         tid = tc.task_create_shell(["echo", "hello world"])
     assert re.match("^[0-9a-f]{32}$", tid)
-    assert (tmp_path / "tasks" / tid).exists()
+    assert (tmp_path / "tasks" / tid / "data").exists()
     d = TaskData.read(root.open_root(tmp_path), tid)
     assert isinstance(d, TaskData)
     assert d.task_id == tid

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,7 +1,6 @@
 import pytest
 
-from hipercow import root
-from hipercow import util
+from hipercow import root, util
 
 
 def test_create_root(tmp_path):

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,6 +1,7 @@
 import pytest
 
 from hipercow import root
+from hipercow import util
 
 
 def test_create_root(tmp_path):
@@ -23,8 +24,7 @@ def test_notify_if_root_exists(tmp_path, capsys):
 
 
 def test_error_if_root_invalid(tmp_path):
-    with open(tmp_path / "hipercow", "w") as _:
-        pass
+    util.file_create(tmp_path / "hipercow")
     with pytest.raises(Exception, match="Unexpected file 'hipercow'"):
         root.init(tmp_path)
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -31,3 +31,7 @@ def test_that_missing_tasks_have_missing_status(tmp_path):
     root.init(tmp_path)
     r = root.open_root(tmp_path)
     assert task_status(r, "a" * 32) == TaskStatus.MISSING
+
+
+def test_can_convert_to_nice_string():
+    assert str(TaskStatus.CREATED) == "created"

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,7 +1,7 @@
 from hipercow import root
-from hipercow.task import TaskStatus, task_status, set_task_status
-from hipercow.util import transient_working_directory
 from hipercow import task_create as tc
+from hipercow.task import TaskStatus, set_task_status, task_status
+from hipercow.util import transient_working_directory
 
 
 def test_can_check_if_tasks_are_runnable():

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,33 @@
+from hipercow import root
+from hipercow.task import TaskStatus, task_status, set_task_status
+from hipercow.util import transient_working_directory
+from hipercow import task_create as tc
+
+
+def test_can_check_if_tasks_are_runnable():
+    assert TaskStatus.CREATED.is_runnable()
+    assert not TaskStatus.CREATED.is_terminal()
+
+    assert not TaskStatus.RUNNING.is_runnable()
+    assert not TaskStatus.RUNNING.is_terminal()
+
+    assert not TaskStatus.SUCCESS.is_runnable()
+    assert TaskStatus.SUCCESS.is_terminal()
+
+
+def test_can_set_task_status(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    with transient_working_directory(tmp_path):
+        tid = tc.task_create_shell(["echo", "hello world"])
+    assert task_status(r, tid) == TaskStatus.CREATED
+    set_task_status(r, tid, TaskStatus.RUNNING)
+    assert task_status(r, tid) == TaskStatus.RUNNING
+    set_task_status(r, tid, TaskStatus.SUCCESS)
+    assert task_status(r, tid) == TaskStatus.SUCCESS
+
+
+def test_that_missing_tasks_have_missing_status(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    assert task_status(r, "a" * 32) == TaskStatus.MISSING


### PR DESCRIPTION
I was going to start with eval, but this is needed first. Note that we reorganise the tasks directory slightly - this was wrong in #1.  We also need to think about what happens here with coexistance of R and python tasks, but I think we're generally ok until someone tries to run tasks of the other type.