### PR TITLE
Refactor driver load within root

### DIFF
--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -6,6 +6,7 @@ import click
 from hipercow import root
 from hipercow.configure import configure, unconfigure
 from hipercow.dide import auth as dide_auth
+from hipercow.driver import list_drivers
 from hipercow.task import TaskStatus, task_list, task_log, task_status
 from hipercow.task_create import task_create_shell
 from hipercow.task_eval import task_eval
@@ -54,7 +55,7 @@ def cli_driver_unconfigure(name: str):
 
 @driver.command("list")
 def cli_driver_list():
-    drivers = root.open_root().list_drivers()
+    drivers = list_drivers(root.open_root())
     if drivers:
         click.echo("\n".join([str(d) for d in drivers]))
     else:

--- a/src/hipercow/driver.py
+++ b/src/hipercow/driver.py
@@ -1,3 +1,4 @@
+import pickle
 from abc import ABC, abstractmethod
 
 from hipercow.root import Root
@@ -12,3 +13,44 @@ class HipercowDriver(ABC):
 
     def submit(self, task_id: str, root: Root) -> None:
         pass  # pragma: no cover
+
+
+def list_drivers(root) -> list[str]:
+    path = root.path / "hipercow" / "config"
+    return [x.name for x in path.glob("*")]
+
+
+def load_driver(root: Root, driver: str | None) -> HipercowDriver:
+    dr = _load_driver(root, driver)
+    if not dr:
+        msg = "No driver configured"
+        raise Exception(msg)
+    return dr
+
+
+def load_driver_optional(
+    root: Root, driver: str | None
+) -> HipercowDriver | None:
+    return _load_driver(root, driver)
+
+
+def _load_driver(root: Root, driver: str | None) -> HipercowDriver | None:
+    if not driver:
+        return _default_driver(root)
+    path = root.path_configuration(driver)
+    if not path.exists():
+        msg = f"No such driver '{driver}'"
+        raise Exception(msg)
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def _default_driver(root: Root) -> HipercowDriver | None:
+    candidates = list_drivers(root)
+    n = len(candidates)
+    if n == 0:
+        return None
+    if n > 1:
+        msg = "More than one candidate driver"
+        raise Exception(msg)
+    return load_driver(root, candidates[0])

--- a/src/hipercow/root.py
+++ b/src/hipercow/root.py
@@ -1,6 +1,4 @@
-import pickle
 from pathlib import Path
-from typing import Any
 
 from hipercow.util import file_create, find_file_descend
 
@@ -60,35 +58,6 @@ class Root:
 
     def path_configuration(self, name: str) -> Path:
         return self.path / "hipercow" / "config" / name
-
-    def load_driver(
-        self, driver: str | None, *, allow_none: bool = False
-    ) -> Any:
-        if not driver:
-            return self._default_configuration(allow_none=allow_none)
-        path = self.path_configuration(driver)
-        if not path.exists():
-            msg = f"No such configuration '{driver}'"
-            raise Exception(msg)
-        with open(path, "rb") as f:
-            return pickle.load(f)
-
-    def list_drivers(self) -> list[str]:
-        path = self.path / "hipercow" / "config"
-        return [x.name for x in path.glob("*")]
-
-    def _default_configuration(self, *, allow_none: bool = False) -> Any:
-        candidates = self.list_drivers()
-        n = len(candidates)
-        if n == 0:
-            if not allow_none:
-                msg = "No driver configured"
-                raise Exception(msg)
-            return None
-        if n > 1:
-            msg = "More than one candidate driver"
-            raise Exception(msg)
-        return self.load_driver(candidates[0])
 
 
 def open_root(path: None | str | Path = None) -> Root:

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -1,5 +1,6 @@
 import secrets
 
+from hipercow.driver import load_driver_optional
 from hipercow.root import Root
 from hipercow.task import TaskData, TaskStatus, set_task_status
 from hipercow.util import relative_workdir
@@ -40,6 +41,6 @@ def _new_task_id() -> str:
 
 
 def _submit_maybe(task_id: str, driver: str | None, root: Root) -> None:
-    if dr := root.load_driver(driver, allow_none=True):
+    if dr := load_driver_optional(root, driver):
         dr.submit(task_id, root)
         set_task_status(root, task_id, TaskStatus.SUBMITTED)

--- a/tests/dide/test_configure.py
+++ b/tests/dide/test_configure.py
@@ -5,6 +5,7 @@ from hipercow.configure import configure
 from hipercow.dide.driver import DideConfiguration
 from hipercow.dide.mounts import Mount, remap_path
 from hipercow.dide.web import Credentials, DideWebClient
+from hipercow.driver import list_drivers, load_driver
 from hipercow.task_create import task_create_shell
 from hipercow.util import transient_working_directory
 
@@ -17,8 +18,8 @@ def test_can_configure_dide_mount(tmp_path, mocker):
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
     configure(r, "dide")
 
-    assert r.list_drivers() == ["dide"]
-    driver = r.load_driver("dide")
+    assert list_drivers(r) == ["dide"]
+    driver = load_driver(r, "dide")
     path_map = remap_path(path, mock_mounts)
     assert driver.config == DideConfiguration(path_map)
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2,6 +2,7 @@ import pytest
 
 from hipercow import root
 from hipercow.configure import _write_configuration, configure, unconfigure
+from hipercow.driver import list_drivers, load_driver, load_driver_optional
 from hipercow.example import ExampleDriver
 
 
@@ -9,12 +10,12 @@ def test_no_drivers_are_available_by_default(tmp_path):
     path = tmp_path / "ex"
     root.init(path)
     r = root.open_root(path)
-    assert r.list_drivers() == []
-    assert r.load_driver(None, allow_none=True) is None
+    assert list_drivers(r) == []
+    assert load_driver_optional(r, None) is None
     with pytest.raises(Exception, match="No driver configured"):
-        r.load_driver(None)
-    with pytest.raises(Exception, match="No such configuration 'example'"):
-        r.load_driver("example")
+        load_driver(r, None)
+    with pytest.raises(Exception, match="No such driver 'example'"):
+        load_driver(r, "example")
 
 
 def test_can_configure_driver(tmp_path):
@@ -22,8 +23,8 @@ def test_can_configure_driver(tmp_path):
     root.init(path)
     r = root.open_root(path)
     configure(r, "example")
-    assert r.list_drivers() == ["example"]
-    assert isinstance(r.load_driver(None), ExampleDriver)
+    assert list_drivers(r) == ["example"]
+    assert isinstance(load_driver(r, None), ExampleDriver)
 
 
 def test_can_unconfigure_driver(tmp_path):
@@ -31,11 +32,11 @@ def test_can_unconfigure_driver(tmp_path):
     root.init(path)
     r = root.open_root(path)
     configure(r, "example")
-    assert r.list_drivers() == ["example"]
+    assert list_drivers(r) == ["example"]
     unconfigure(r, "example")
-    assert r.list_drivers() == []
+    assert list_drivers(r) == []
     unconfigure(r, "example")
-    assert r.list_drivers() == []
+    assert list_drivers(r) == []
 
 
 def test_throw_if_unknown_driver(tmp_path):
@@ -70,4 +71,4 @@ def test_get_default_driver(tmp_path):
     _write_configuration(r, a)
     _write_configuration(r, b)
     with pytest.raises(Exception, match="More than one candidate driver"):
-        r.load_driver(None)
+        load_driver(r, None)


### PR DESCRIPTION
This PR updates how we load and list drivers from the root, which will simplify imports a bit later.  Basically, things that were methods on the root object move to free functions in the root module, taking the Root object as an argument.  The boolean argument for controlling if a driver is required to be returned is replaced by two different functions - `load_driver` (always returns a driver) and `load_driver_optional` which returns a driver or `None`.  This change simplifies the type-checking later.