### PR TITLE
Implement basic environment engines

### DIFF
--- a/src/hipercow/environment.py
+++ b/src/hipercow/environment.py
@@ -1,6 +1,11 @@
 import pickle
 from dataclasses import dataclass
 
+from hipercow.environment_engines import (
+    Empty,
+    EnvironmentEngine,
+    Pip,
+)
 from hipercow.root import Root
 
 
@@ -34,8 +39,8 @@ def environment_new(root: Root, name: str, engine: str) -> None:
         msg = f"Environment '{name}' already exists"
         raise Exception(msg)
 
-    if engine not in {"empty", "pip"}:
-        msg = "Only the 'empty' and 'pip' engines are supported"
+    if engine not in {"pip", "empty"}:
+        msg = "Only the 'pip' and 'empty' engines are supported"
         raise Exception(msg)
 
     print(f"Creating environment '{name}' using '{engine}'")
@@ -59,3 +64,18 @@ def environment_check(root: Root, name: str | None) -> str:
 
 def environment_exists(root: Root, name: str) -> bool:
     return root.path_environment(name).exists()
+
+
+def environment_engine(root: Root, name: str) -> EnvironmentEngine:
+    use_empty_environment = name == "empty" or (
+        name == "default" and not environment_exists(root, name)
+    )
+    if use_empty_environment:
+        cfg = EnvironmentConfiguration("empty")
+    else:
+        cfg = EnvironmentConfiguration.read(root, name)
+    if cfg.engine == "pip":
+        return Pip(root, name)
+    elif cfg.engine == "empty":
+        return Empty(root, name)
+    raise NotImplementedError()

--- a/src/hipercow/environment.py
+++ b/src/hipercow/environment.py
@@ -78,4 +78,4 @@ def environment_engine(root: Root, name: str) -> EnvironmentEngine:
         return Pip(root, name)
     elif cfg.engine == "empty":
         return Empty(root, name)
-    raise NotImplementedError()
+    raise NotImplementedError()  # pragma no cover

--- a/src/hipercow/environment_engines/__init__.py
+++ b/src/hipercow/environment_engines/__init__.py
@@ -1,0 +1,5 @@
+from hipercow.environment_engines.base import EnvironmentEngine, Platform
+from hipercow.environment_engines.empty import Empty
+from hipercow.environment_engines.pip import Pip
+
+__all__ = ["Empty", "EnvironmentEngine", "Pip", "Platform"]

--- a/src/hipercow/environment_engines/base.py
+++ b/src/hipercow/environment_engines/base.py
@@ -1,0 +1,51 @@
+import platform
+import subprocess
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+from hipercow.root import Root
+
+
+# We don't want to call actual 'platform' code very often because our
+# intent is that we're generating things for another system.
+@dataclass
+class Platform:
+    system: str
+    version: str
+
+    @staticmethod
+    def local() -> "Platform":
+        return Platform(platform.system().lower(), platform.python_version())
+
+
+class EnvironmentEngine(ABC):
+    def __init__(self, root: Root, name: str, platform: Platform | None = None):
+        self.root = root
+        self.name = name
+        self.platform = platform or Platform.local()
+
+    def exists(self) -> bool:
+        return self.path().exists()
+
+    @abstractmethod
+    def path(self) -> Path:
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def create(self, **kwargs) -> None:
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def provision(self, cmd: list[str] | None, **kwargs) -> None:
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        **kwargs,
+    ) -> subprocess.CompletedProcess:
+        pass  # pragma: no cover

--- a/src/hipercow/environment_engines/empty.py
+++ b/src/hipercow/environment_engines/empty.py
@@ -17,6 +17,7 @@ class Empty(EnvironmentEngine):
         msg = "The empty environment has no path"
         raise Exception(msg)
 
+    # These "unused argument" errors from ruff are probably a bug?
     def create(self, **kwargs) -> None:  # noqa: ARG002
         msg = "Can't create the empty environment!"
         raise Exception(msg)
@@ -27,7 +28,6 @@ class Empty(EnvironmentEngine):
         msg = "Can't provision the empty environment!"
         raise Exception(msg)
 
-    # These "unused argument" errors from ruff are probably a bug?
     def run(
         self,
         cmd: list[str],

--- a/src/hipercow/environment_engines/empty.py
+++ b/src/hipercow/environment_engines/empty.py
@@ -1,0 +1,38 @@
+import subprocess
+from pathlib import Path
+
+from hipercow.environment_engines.base import EnvironmentEngine, Platform
+from hipercow.root import Root
+from hipercow.util import subprocess_run
+
+
+class Empty(EnvironmentEngine):
+    def __init__(self, root: Root, name: str, platform: Platform | None = None):
+        super().__init__(root, name, platform)
+
+    def exists(self) -> bool:
+        return True
+
+    def path(self) -> Path:
+        msg = "The empty environment has no path"
+        raise Exception(msg)
+
+    def create(self, **kwargs) -> None:  # noqa: ARG002
+        msg = "Can't create the empty environment!"
+        raise Exception(msg)
+
+    def provision(
+        self, cmd: list[str] | None, **kwargs  # noqa: ARG002
+    ) -> None:
+        msg = "Can't provision the empty environment!"
+        raise Exception(msg)
+
+    # These "unused argument" errors from ruff are probably a bug?
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        **kwargs,
+    ) -> subprocess.CompletedProcess:
+        return subprocess_run(cmd, env=env, **kwargs)

--- a/src/hipercow/environment_engines/pip.py
+++ b/src/hipercow/environment_engines/pip.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+from pathlib import Path
+
+from hipercow.environment_engines.base import EnvironmentEngine, Platform
+from hipercow.root import Root
+from hipercow.util import subprocess_run
+
+
+class Pip(EnvironmentEngine):
+    def __init__(self, root: Root, name: str, platform: Platform | None = None):
+        super().__init__(root, name, platform)
+
+    def path(self) -> Path:
+        return (
+            self.root.path_environment_contents(self.name)
+            / f"venv-{self.platform.system}"
+        )
+
+    def create(self, **kwargs) -> None:
+        # do we need to specify the actual python version here, or do
+        # we assume that we have the correct version?  If we check
+        # that the version here matches that in self.platform we're ok.
+        cmd = ["python", "-m", "venv", str(self.path())]
+        subprocess_run(cmd, check=True, **kwargs)
+
+    def provision(self, cmd: list[str] | None, **kwargs) -> None:
+        self.run(self._check_args(cmd), check=True, **kwargs)
+
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        **kwargs,
+    ) -> subprocess.CompletedProcess:
+        env = (env or {}) | self._envvars()
+        return subprocess_run(cmd, env=env, **kwargs)
+
+    def _envvars(self) -> dict[str, str]:
+        base = self.path()
+        path_env = base / self._venv_bin_dir()
+        path = f"{path_env}{os.pathsep}{os.environ['PATH']}"
+        return {"VIRTUAL_ENV": str(base), "PATH": path}
+
+    def _auto(self) -> list[str]:
+        if Path("pyproject.toml").exists():
+            return ["pip", "install", "--verbose", "."]
+        if Path("requirements.txt").exists():
+            return ["pip", "install", "--verbose", "-r", "requirements.txt"]
+        msg = "Can't determine install command"
+        raise Exception(msg)
+
+    def _check_args(self, cmd: list[str] | None) -> list[str]:
+        if not cmd:
+            return self._auto()
+        if cmd[0] != "pip":
+            msg = "Expected first element of 'cmd' to be 'pip'"
+            raise Exception(msg)
+        return cmd
+
+    def _venv_bin_dir(self) -> str:
+        return "Scripts" if self.platform.system == "windows" else "bin"

--- a/src/hipercow/root.py
+++ b/src/hipercow/root.py
@@ -69,6 +69,11 @@ class Root:
     def path_environment_config(self, name: str) -> Path:
         return self.path_environment(name) / "config"
 
+    def path_environment_contents(
+        self, name: str, *, relative: bool = False
+    ) -> Path:
+        return self.path_environment(name, relative=relative) / "contents"
+
 
 def open_root(path: None | str | Path = None) -> Root:
     root = find_file_descend("hipercow", path or Path.cwd())

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -49,5 +49,5 @@ def test_environment_selection(tmp_path):
 def test_require_pip_environment_engine(tmp_path):
     root.init(tmp_path)
     r = root.open_root(tmp_path)
-    with pytest.raises(Exception, match="Only the 'empty' and 'pip'"):
+    with pytest.raises(Exception, match="Only the 'pip' and 'empty'"):
         environment_new(r, "default", "conda")

--- a/tests/test_environment_empty.py
+++ b/tests/test_environment_empty.py
@@ -1,0 +1,53 @@
+from unittest import mock
+
+import pytest
+
+from hipercow import root
+from hipercow.environment_engines import Empty
+from hipercow.environment import environment_engine
+
+
+def test_empty_environment_has_no_path_but_always_exists(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    env = Empty(r, "empty")
+
+    assert env.exists()
+    with pytest.raises(Exception, match="The empty environment has no path"):
+        env.path()
+
+
+def test_can_load_empty_engine(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    assert isinstance(environment_engine(r, "empty"), Empty)
+    assert isinstance(environment_engine(r, "default"), Empty)
+
+
+def test_empty_environment_cannot_be_created(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    env = Empty(r, "empty")
+    with pytest.raises(Exception, match="Can't create the empty environment!"):
+        env.create()
+
+
+def test_empty_environment_cannot_be_provisioned(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    env = Empty(r, "empty")
+    with pytest.raises(Exception, match="Can't provision the empty"):
+        env.provision([])
+
+
+def test_can_run_command_in_empty_env(tmp_path, mocker):
+    mock_run = mock.MagicMock()
+    mocker.patch("subprocess.run", mock_run)
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    env = Empty(r, "empty")
+    env.run(["some", "command"])
+    assert mock_run.call_count == 1
+    assert mock_run.mock_calls[0] == mock.call(
+        ["some", "command"], env=None, check=False
+    )

--- a/tests/test_environment_empty.py
+++ b/tests/test_environment_empty.py
@@ -3,8 +3,8 @@ from unittest import mock
 import pytest
 
 from hipercow import root
-from hipercow.environment_engines import Empty
 from hipercow.environment import environment_engine
+from hipercow.environment_engines import Empty
 
 
 def test_empty_environment_has_no_path_but_always_exists(tmp_path):

--- a/tests/test_environment_pip.py
+++ b/tests/test_environment_pip.py
@@ -1,0 +1,78 @@
+from unittest import mock
+
+import pytest
+
+from hipercow import root
+from hipercow.environment import environment_engine, environment_new
+from hipercow.environment_engines import Pip
+from hipercow.util import file_create, transient_working_directory
+
+
+def test_pip_environment_does_not_exist_until_created(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    env = Pip(r, "default")
+    assert not env.exists()
+    env.path().mkdir(parents=True)
+    assert env.exists()
+
+
+def test_pip_environment_can_be_created(tmp_path, mocker):
+    mock_run = mock.MagicMock()
+    mocker.patch("subprocess.run", mock_run)
+
+    root.init(tmp_path)
+    file_create(tmp_path / "requirements.txt")
+    r = root.open_root(tmp_path)
+    environment_new(r, "default", "pip")
+    env = environment_engine(r, "default")
+    assert isinstance(env, Pip)
+
+    venv_path = str(env.path())
+    envvars = env._envvars()
+
+    env.create()
+    assert mock_run.call_count == 1
+    assert mock_run.mock_calls[0] == mock.call(
+        ["python", "-m", "venv", venv_path], check=True
+    )
+
+    with transient_working_directory(tmp_path):
+        env.provision(None)
+        assert mock_run.call_count == 2
+        assert mock_run.mock_calls[1] == mock.call(
+            ["pip", "install", "--verbose", "-r", "requirements.txt"],
+            env=envvars,
+            check=True,
+        )
+
+
+def test_pip_can_determine_sensible_default_cmd(tmp_path):
+    root.init(tmp_path)
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    env = Pip(r, "default")
+
+    with transient_working_directory(tmp_path):
+        with pytest.raises(Exception, match="Can't determine install"):
+            env._auto()
+        file_create(tmp_path / "requirements.txt")
+        assert env._auto() == [
+            "pip",
+            "install",
+            "--verbose",
+            "-r",
+            "requirements.txt",
+        ]
+        file_create(tmp_path / "pyproject.toml")
+        assert env._auto() == ["pip", "install", "--verbose", "."]
+
+        assert env._check_args(None) == ["pip", "install", "--verbose", "."]
+        assert env._check_args([]) == ["pip", "install", "--verbose", "."]
+        assert env._check_args(["pip", "install", "x"]) == [
+            "pip",
+            "install",
+            "x",
+        ]
+        with pytest.raises(Exception, match="Expected first element"):
+            assert env._check_args(["pwd"])


### PR DESCRIPTION
Merge after #18, contains those commits

This PR adds environment engines for pip and the empty engine.  This one is not in itself useful, the next one starts on real provisioning via the drivers, which will be much more interesting