### PR TITLE
Add support for deleting environments

### DIFF
--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -7,7 +7,11 @@ from hipercow import root
 from hipercow.configure import configure, unconfigure
 from hipercow.dide import auth as dide_auth
 from hipercow.driver import list_drivers
-from hipercow.environment import environment_list, environment_new
+from hipercow.environment import (
+    environment_delete,
+    environment_list,
+    environment_new,
+)
 from hipercow.provision import provision
 from hipercow.task import TaskStatus, task_list, task_log, task_status
 from hipercow.task_create import task_create_shell
@@ -145,6 +149,13 @@ def environment():
 def cli_environment_list():
     envs = environment_list(root.open_root())
     click.echo("\n".join(envs))
+
+
+@environment.command("delete")
+@click.option("--name")
+def cli_environment_delete(name: str):
+    r = root.open_root()
+    environment_delete(r, name)
 
 
 @environment.command("new")

--- a/src/hipercow/environment.py
+++ b/src/hipercow/environment.py
@@ -1,4 +1,5 @@
 import pickle
+import shutil
 from dataclasses import dataclass
 
 from hipercow.environment_engines import (
@@ -51,6 +52,25 @@ def environment_list(root: Root) -> list[str]:
     special = ["empty"]
     found = [x.name for x in (root.path / "hipercow" / "env").glob("*")]
     return sorted(special + found)
+
+
+def environment_delete(root: Root, name: str) -> None:
+    if name == "empty":
+        msg = "Can't delete the empty environment"
+        raise Exception(msg)
+    if not environment_exists(root, name):
+        if name == "default":
+            reason = "it is empty"
+        else:
+            reason = "it does not exist"
+        msg = f"Can't delete environment '{name}', as {reason}"
+        raise Exception(msg)
+    print(
+        f"Attempting to delete environment '{name}'; this might fail if "
+        "files are in use on a network share, in which case you should ",
+        "try again later",
+    )
+    shutil.rmtree(str(root.path_environment(name)))
 
 
 def environment_check(root: Root, name: str | None) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,3 +208,24 @@ def test_can_provision_environment(tmp_path, mocker):
         assert mock_provision.mock_calls[1] == mock.call(
             mock.ANY, "foo", ["pip", "install", "."]
         )
+
+
+def test_can_delete_environment(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        runner.invoke(cli.init, ".")
+        runner.invoke(cli.cli_driver_configure, ["example"])
+        res = runner.invoke(cli.cli_environment_new, ["--name", "other"])
+        assert res.exit_code == 0
+        assert res.output == "Creating environment 'other' using 'pip'\n"
+
+        res = runner.invoke(cli.cli_environment_list, [])
+        assert res.exit_code == 0
+        assert res.output == "empty\nother\n"
+
+        res = runner.invoke(cli.cli_environment_delete, ["--name", "other"])
+        assert res.exit_code == 0
+
+        res = runner.invoke(cli.cli_environment_list, [])
+        assert res.exit_code == 0
+        assert res.output == "empty\n"


### PR DESCRIPTION
This can be reviewed/merged separately from #21, it's independent.

Basic support for deleting environments.  There's still a bit of weirdness about the `default` environment and if it really exists, but the deletion logic itself is fairly simple.