### PR TITLE
Add hostname to driver configuration

### DIFF
--- a/src/hipercow/driver.py
+++ b/src/hipercow/driver.py
@@ -1,4 +1,5 @@
 import pickle
+import platform
 from abc import ABC, abstractmethod
 
 from hipercow.root import Root
@@ -16,7 +17,8 @@ class HipercowDriver(ABC):
 
 
 def list_drivers(root) -> list[str]:
-    path = root.path / "hipercow" / "config"
+    hostname = platform.node()
+    path = root.path / "hipercow" / "config" / hostname
     return [x.name for x in path.glob("*")]
 
 

--- a/src/hipercow/root.py
+++ b/src/hipercow/root.py
@@ -1,3 +1,4 @@
+import platform
 from pathlib import Path
 
 from hipercow.util import file_create, find_file_descend
@@ -60,7 +61,8 @@ class Root:
         return self.path_task(task_id) / "log"
 
     def path_configuration(self, name: str) -> Path:
-        return self.path / "hipercow" / "config" / name
+        hostname = platform.node()
+        return self.path / "hipercow" / "config" / hostname / name
 
     def path_environment(self, name: str, *, relative: bool = False) -> Path:
         base = self.path_base(relative=relative)


### PR DESCRIPTION
Pretty simple fix - the hostname is added to the driver configuration path which should help in the cases where a user has two different computers targeting the same hipercow root

The corresponding R PR is here: https://github.com/mrc-ide/hipercow/pull/146/files - but this needed to cope with migration of old configurations, which we can safely skip