### PR TITLE
Better behaviour where command not found

### DIFF
--- a/src/hipercow/util.py
+++ b/src/hipercow/util.py
@@ -46,15 +46,25 @@ def subprocess_run(
     **kwargs,
 ) -> subprocess.CompletedProcess:
     env = os.environ | (env or {})
-    if filename is None:
-        return subprocess.run(cmd, **kwargs, check=check, env=env)
-    else:
-        with filename.open("ab") as f:
-            return subprocess.run(
-                cmd,
-                check=check,
-                env=env,
-                stderr=subprocess.STDOUT,
-                stdout=f,
-                **kwargs,
-            )
+    try:
+        if filename is None:
+            return subprocess.run(cmd, **kwargs, check=check, env=env)
+        else:
+            with filename.open("ab") as f:
+                return subprocess.run(
+                    cmd,
+                    check=check,
+                    env=env,
+                    stderr=subprocess.STDOUT,
+                    stdout=f,
+                    **kwargs,
+                )
+    except FileNotFoundError as err:
+        if check:
+            raise err
+        elif filename is None:
+            print(err)
+        else:
+            with filename.open("a") as f:
+                print(err, file=f)
+        return subprocess.CompletedProcess(cmd, -1)

--- a/tests/test_task_eval.py
+++ b/tests/test_task_eval.py
@@ -40,3 +40,15 @@ def test_can_capture_output_to_auto_file(tmp_path):
         assert f.read().strip() == "hello world"
 
     assert task_log(r, tid) == "hello world\n"
+
+
+def test_return_information_about_failure_to_find_path(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    with transient_working_directory(tmp_path):
+        tid = tc.task_create_shell(r, ["adsfasdfasdfa", "arg"])
+    task_eval(r, tid, capture=True)
+
+    path = r.path_task_log(tid)
+    assert path.exists()
+    assert task_status(r, tid) == TaskStatus.FAILURE

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from hipercow.util import (
     find_file_descend,
     subprocess_run,
@@ -32,3 +34,22 @@ def test_run_process_and_capture_output(tmp_path):
     assert path.exists()
     with open(path) as f:
         assert f.read().strip() == "hello"
+
+
+def test_can_cope_with_missing_path(tmp_path, capsys):
+    cmd = ["nosuchexe", "arg"]
+
+    res = subprocess_run(cmd)
+    assert res.args == cmd
+    assert res.returncode == -1
+    out = capsys.readouterr()
+    assert len(out.out) > 0
+
+    tmp = tmp_path / "log"
+    res = subprocess_run(cmd, filename=tmp)
+    assert capsys.readouterr().out == ""
+    assert res.args == cmd
+    assert res.returncode == -1
+
+    with pytest.raises(FileNotFoundError):
+        res = subprocess_run(cmd, check=True)


### PR DESCRIPTION
Currently if you add a task that fails when finding the command, it fails catstrophically because we end up with an uncaught error in `subprocess_run`. This PR wraps the call to `subprocess.run` within `try/except` looking for the exception that subprocess throws if it can't start the process.  This respects our handling of `check` (throw if `check=False`) and the output capture.