### PR TITLE
Add wait option to task create

### DIFF
--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -111,10 +111,13 @@ def cli_task_list(with_status=None):
 @task.command("create")
 @click.argument("cmd", nargs=-1)
 @click.option("--environment", type=str)
-def cli_task_create(cmd: tuple[str], environment: str | None):
+@click.option("--wait", is_flag=True)
+def cli_task_create(cmd: tuple[str], environment: str | None, *, wait: bool):
     r = root.open_root()
     task_id = task_create_shell(r, list(cmd), environment=environment)
     click.echo(task_id)
+    if wait:
+        task_wait(r, task_id)
 
 
 @task.command("eval")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,3 +289,20 @@ def test_can_build_environment(tmp_path, mocker):
         assert mock_provision.mock_calls[0] == mock.call(
             mock.ANY, "example", "abcdef"
         )
+
+
+def test_can_create_on_task_and_wait(tmp_path, mocker):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        runner.invoke(cli.init, ".")
+        mocker.patch("hipercow.cli.task_wait")
+        res = runner.invoke(
+            cli.cli_task_create, ["--wait", "echo", "hello", "world"]
+        )
+        assert res.exit_code == 0
+        task_id = res.stdout.strip()
+        assert cli.task_wait.call_count == 1
+        assert cli.task_wait.mock_calls[0] == mock.call(
+            mock.ANY,
+            task_id,
+        )


### PR DESCRIPTION
As discussed - this creates a blocking version of task create.  It does not allow forwarding of other options to task wait