### PR TITLE
Add integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,12 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "pytest-mock",
+  "pytest-explicit",
   "responses",
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests} --run-slow"
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=hipercow --cov=tests {args}"
 no-cov = "cov --no-cov {args}"
 cov-report-xml = [
@@ -176,3 +177,11 @@ unfixable = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.pytest.ini_options]
+markers = [
+   "slow: slower integration tests",
+]
+explicit-only = [
+    "slow",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests} --run-slow"
+test-cov = "coverage run -m pytest {args:tests} --run-all"
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=hipercow --cov=tests {args}"
 no-cov = "cov --no-cov {args}"
 cov-report-xml = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--longrun",
+        action="store_true",
+        dest="longrun",
+        default=False,
+        help="enable longrundecorated tests",
+    )

--- a/tests/zzz/test_environment.py
+++ b/tests/zzz/test_environment.py
@@ -9,10 +9,8 @@ from hipercow.task_create import task_create_shell
 from hipercow.task_eval import task_eval
 from hipercow.util import transient_working_directory
 
-longrun = pytest.mark.skipif("not config.getoption('longrun')")
 
-
-@longrun
+@pytest.mark.slow
 def test_run_in_environment(tmp_path):
     with transient_working_directory(tmp_path):
         root.init(tmp_path)

--- a/tests/zzz/test_environment.py
+++ b/tests/zzz/test_environment.py
@@ -13,7 +13,6 @@ from hipercow.util import transient_working_directory
 @pytest.mark.slow
 def test_run_in_environment(tmp_path):
     with transient_working_directory(tmp_path):
-        assert tmp_path == "a"
         root.init(tmp_path)
         r = root.open_root(tmp_path)
 

--- a/tests/zzz/test_environment.py
+++ b/tests/zzz/test_environment.py
@@ -13,6 +13,7 @@ from hipercow.util import transient_working_directory
 @pytest.mark.slow
 def test_run_in_environment(tmp_path):
     with transient_working_directory(tmp_path):
+        assert tmp_path == "a"
         root.init(tmp_path)
         r = root.open_root(tmp_path)
 

--- a/tests/zzz/test_environment.py
+++ b/tests/zzz/test_environment.py
@@ -1,0 +1,31 @@
+import pytest
+
+from hipercow import root
+from hipercow.configure import configure
+from hipercow.environment import environment_new
+from hipercow.provision import provision
+from hipercow.task import TaskStatus, task_log, task_status
+from hipercow.task_create import task_create_shell
+from hipercow.task_eval import task_eval
+from hipercow.util import transient_working_directory
+
+longrun = pytest.mark.skipif("not config.getoption('longrun')")
+
+
+@longrun
+def test_run_in_environment(tmp_path):
+    with transient_working_directory(tmp_path):
+        root.init(tmp_path)
+        r = root.open_root(tmp_path)
+
+        with open("requirements.txt", "w") as f:
+            f.write("cowsay\n")
+
+        configure(r, "example")
+        environment_new(r, "default", "pip")
+        provision(r, "default", [])
+        tid = task_create_shell(r, ["cowsay", "-t", "hello"])
+        task_eval(r, tid, capture=True)
+
+        assert task_status(r, tid) == TaskStatus.SUCCESS
+        assert "| hello |" in task_log(r, tid)


### PR DESCRIPTION
I've put them within `zzz` as this organises running them last easily. There might be other better ways of doing this, but it's obvious at least.  I used the `pytest-explicit` plug-in to organise running tests marked as "slow" only if explicitly asked for - we do this by adding `--run-slow` (see https://github.com/cryptaliagy/pytest-explicit).

The integration test is hopefully useful - it only takes a few seconds but it does use networking and will be a failure point. Note that it always runs on CI, as the `test-cov` command will run it.

There's at least one bug lurking where if the integration test commands aren't all run at the root of the hipercow directory we write into the wrong place and things go a bit poorly.  I'll fix that in a separate PR and probably add another integration test

See the test failure on the build for 01a4280 (now rebased off main but the same code as cfad249), which introduces a failing test into the integration test.