### PR TITLE
Allow python and R to coexist

### DIFF
--- a/src/hipercow/driver.py
+++ b/src/hipercow/driver.py
@@ -1,5 +1,4 @@
 import pickle
-import platform
 from abc import ABC, abstractmethod
 
 from hipercow.root import Root
@@ -22,8 +21,7 @@ class HipercowDriver(ABC):
 
 
 def list_drivers(root) -> list[str]:
-    hostname = platform.node()
-    path = root.path / "hipercow" / "config" / hostname
+    path = root.path_configuration(None)
     return [x.name for x in path.glob("*")]
 
 

--- a/src/hipercow/environment.py
+++ b/src/hipercow/environment.py
@@ -50,7 +50,8 @@ def environment_new(root: Root, name: str, engine: str) -> None:
 
 def environment_list(root: Root) -> list[str]:
     special = ["empty"]
-    found = [x.name for x in (root.path / "hipercow" / "env").glob("*")]
+    path = root.path_environment(None)
+    found = [x.name for x in path.glob("*")]
     return sorted(special + found)
 
 

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -147,7 +147,7 @@ def task_info(root: Root, task_id: str) -> TaskInfo:
 def task_list(
     root: Root, *, with_status: TaskStatus | None = None
 ) -> list[str]:
-    contents = (root.path / "hipercow" / "tasks").rglob("data")
+    contents = root.path_task(None).rglob("data")
     ids = ["".join(el.parts[-3:-1]) for el in contents if el.is_file()]
     if with_status is not None:
         ids = [i for i in ids if task_status(root, i) & with_status]

--- a/tests/dide/test_batch.py
+++ b/tests/dide/test_batch.py
@@ -32,7 +32,7 @@ def test_can_write_batch(tmp_path):
         tid = tc.task_create_shell(r, ["echo", "hello world"])
 
     unc = batch.write_batch_task_run(tid, path_map, r)
-    path_rel = f"hipercow/tasks/{tid[:2]}/{tid[2:]}/task_run.bat"
+    path_rel = f"hipercow/py/tasks/{tid[:2]}/{tid[2:]}/task_run.bat"
     assert unc == f"//wpia-hn/didehomes/bob/my/project/{path_rel}"
     assert (r.path / path_rel).exists()
 
@@ -59,6 +59,6 @@ def test_can_write_provision_batch(tmp_path):
     r = root.open_root(tmp_path)
 
     unc = batch.write_batch_provision("myenv", "abcdef", path_map, r)
-    path_rel = "hipercow/env/myenv/provision/abcdef/run.bat"
+    path_rel = "hipercow/py/env/myenv/provision/abcdef/run.bat"
     assert unc == f"//wpia-hn/didehomes/bob/my/project/{path_rel}"
     assert (r.path / path_rel).exists()

--- a/tests/dide/test_provision.py
+++ b/tests/dide/test_provision.py
@@ -27,7 +27,7 @@ def test_can_provision_with_dide(tmp_path, mocker):
 
     assert mock_client.submit.call_count == 1
     assert mock_client.mock_calls[0] == mock.call.submit(
-        "//host//hostmount/path/to/dir/hipercow/env/myenv/provision/abcdef/run.bat",
+        "//host//hostmount/path/to/dir/hipercow/py/env/myenv/provision/abcdef/run.bat",
         "myenv/abcdef",
     )
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -15,7 +15,9 @@ def test_create_simple_task(tmp_path):
     with transient_working_directory(tmp_path):
         tid = tc.task_create_shell(r, ["echo", "hello world"])
     assert re.match("^[0-9a-f]{32}$", tid)
-    path_data = tmp_path / "hipercow" / "tasks" / tid[:2] / tid[2:] / "data"
+    path_data = (
+        tmp_path / "hipercow" / "py" / "tasks" / tid[:2] / tid[2:] / "data"
+    )
     assert path_data.exists()
     d = TaskData.read(root.open_root(tmp_path), tid)
     assert isinstance(d, TaskData)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 
 from hipercow import root, util
@@ -8,7 +10,7 @@ def test_create_root(tmp_path):
     root.init(path)
     assert path.exists()
     assert path.is_dir()
-    assert (path / "hipercow" / "py").exists()
+    assert (path / "hipercow" / "py").is_dir()
     r = root.open_root(path)
     assert isinstance(r, root.Root)
     assert r.path == path
@@ -33,8 +35,9 @@ def test_notify_if_root_exists_below_requested(tmp_path, capsys):
 
 
 def test_error_if_root_invalid(tmp_path):
-    util.file_create(tmp_path / "hipercow")
-    with pytest.raises(Exception, match="Unexpected file 'hipercow'"):
+    (tmp_path / "hipercow").mkdir()
+    util.file_create(tmp_path / "hipercow" / "py")
+    with pytest.raises(Exception, match="Unexpected file 'hipercow/py'"):
         root.init(tmp_path)
 
 
@@ -45,7 +48,7 @@ def test_error_if_root_does_not_exist(tmp_path):
 
 def test_error_if_non_python_hipercow_root_found(tmp_path):
     root.init(tmp_path)
-    (tmp_path / "hipercow" / "py").unlink()
+    shutil.rmtree(tmp_path / "hipercow" / "py")
     pat = "Failed to open non-python 'hipercow' root at"
     with pytest.raises(Exception, match=pat):
         root.Root(tmp_path)


### PR DESCRIPTION
This PR moves all hipercow files into `hipercow/py/`, totally isolating them from the R files.  We'll want to do the same trick on the R side too, but it will require a little care to ensure that we can keep going with existing work.