### PR TITLE
Allow selecting python version in config

### DIFF
--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -4,7 +4,7 @@ from operator import ior
 import click
 
 from hipercow import root
-from hipercow.configure import configure, unconfigure
+from hipercow.configure import configure, show_configuration, unconfigure
 from hipercow.dide import auth as dide_auth
 from hipercow.driver import list_drivers
 from hipercow.environment import (
@@ -63,6 +63,13 @@ def cli_driver_configure(name: str):
 def cli_driver_unconfigure(name: str):
     r = root.open_root()
     unconfigure(r, name)
+
+
+@driver.command("show")
+@click.argument("name", required=False)
+def cli_driver_show(name: str | None):
+    r = root.open_root()
+    show_configuration(r, name)
 
 
 @driver.command("list")

--- a/src/hipercow/configure.py
+++ b/src/hipercow/configure.py
@@ -1,7 +1,7 @@
 import pickle
 
 from hipercow.dide.driver import DideDriver
-from hipercow.driver import HipercowDriver
+from hipercow.driver import HipercowDriver, load_driver
 from hipercow.example import ExampleDriver
 from hipercow.root import Root
 from hipercow.util import transient_working_directory
@@ -28,6 +28,12 @@ def unconfigure(root: Root, name: str) -> None:
         print(
             f"Did not remove configuration for '{name}' as it was not enabled"
         )
+
+
+def show_configuration(root: Root, driver: str | None = None) -> None:
+    dr = load_driver(root, driver)
+    print(f"Configuration for '{dr.name}'")
+    dr.show_configuration()
 
 
 # ahead of some sort of global store of drivers:

--- a/src/hipercow/dide/configuration.py
+++ b/src/hipercow/dide/configuration.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from hipercow.dide.mounts import Mount, PathMap, remap_path
+from hipercow.root import Root
+from hipercow.util import check_python_version
+
+
+@dataclass
+class DideConfiguration:
+    path_map: PathMap
+    python_version: str
+
+    def __init__(
+        self, root: Root, *, mounts: list[Mount], python_version: str | None
+    ):
+        self.path_map = remap_path(root.path, mounts)
+        self.python_version = check_python_version(python_version)

--- a/src/hipercow/dide/configuration.py
+++ b/src/hipercow/dide/configuration.py
@@ -11,7 +11,11 @@ class DideConfiguration:
     python_version: str
 
     def __init__(
-        self, root: Root, *, mounts: list[Mount], python_version: str | None
+        self,
+        root: Root,
+        *,
+        mounts: list[Mount],
+        python_version: str | None = None,
     ):
         self.path_map = remap_path(root.path, mounts)
         self.python_version = check_python_version(python_version)

--- a/src/hipercow/dide/driver.py
+++ b/src/hipercow/dide/driver.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from taskwait import Task, taskwait
 
 from hipercow.dide.auth import fetch_credentials
@@ -9,6 +11,7 @@ from hipercow.root import Root
 from hipercow.util import check_python_version
 
 
+@dataclass
 class DideConfiguration:
     path_map: PathMap
     python_version: str
@@ -29,8 +32,8 @@ class DideDriver(HipercowDriver):
         self.config = DideConfiguration(root, mounts=mounts, **kwargs)
 
     def show_configuration(self) -> None:
-        path_map  = self.config.path_map
-        print(f"path mapping:")
+        path_map = self.config.path_map
+        print("path mapping:")
         print(f"  drive: {path_map.remote}")
         print(f"  share: \\\\{path_map.mount.host}\\{path_map.mount.remote}")
         print(f"python version: {self.config.python_version}")

--- a/src/hipercow/driver.py
+++ b/src/hipercow/driver.py
@@ -12,6 +12,10 @@ class HipercowDriver(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
+    def show_configuration(self) -> None:
+        pass  # pragma: no cover
+
+    @abstractmethod
     def submit(self, task_id: str, root: Root) -> None:
         pass  # pragma: no cover
 

--- a/src/hipercow/example.py
+++ b/src/hipercow/example.py
@@ -9,6 +9,9 @@ class ExampleDriver(HipercowDriver):
     def __init__(self, root: Root, **kwargs):
         pass
 
+    def show_configuration(self) -> None:
+        print("(no configuration)")
+
     def submit(self, task_id, root: Root) -> None:  # noqa: ARG002
         print(f"submitting '{task_id}'")
 

--- a/src/hipercow/util.py
+++ b/src/hipercow/util.py
@@ -1,4 +1,6 @@
 import os
+import platform
+import re
 import subprocess
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -86,3 +88,22 @@ def subprocess_run(
             with filename.open("a") as f:
                 print(err, file=f)
         return subprocess.CompletedProcess(cmd, -1)
+
+
+def check_python_version(
+    version: str | None, valid: list[str] | None = None
+) -> str:
+    if valid is None:
+        valid = ["3.10", "3.11", "3.12", "3.13"]
+    if not version:
+        v = ".".join(platform.python_version_tuple()[:2])
+    else:
+        m = re.match(r"^([0-9]+)\.([0-9]+)(\.[0-9]+)?$", version)
+        if not m:
+            msg = f"'{version}' does not parse as a valid version string"
+            raise Exception(msg)
+        v = ".".join(m.groups()[:2])
+    if v not in valid:
+        msg = f"Version '{version}' is not supported"
+        raise Exception(msg)
+    return v

--- a/tests/dide/test_batch.py
+++ b/tests/dide/test_batch.py
@@ -1,64 +1,72 @@
-from pathlib import Path
-
 from hipercow import root
 from hipercow import task_create as tc
 from hipercow.dide import batch
-from hipercow.dide.mounts import Mount, PathMap
+from hipercow.dide.configuration import DideConfiguration
+from hipercow.dide.mounts import Mount
 from hipercow.util import transient_working_directory
 
 
-def test_can_create_batch_data():
-    m = Mount("wpia-hn", "didehomes/bob", "/mnt/nethome")
-    path_map = PathMap(Path("some/path"), m, "Q:", "my/project")
-    res = batch._template_data_task_run("abcde", path_map)
+def test_can_create_batch_data(tmp_path):
+    path = tmp_path / "my/project"
+    root.init(path)
+    r = root.open_root(path)
+    m = Mount("wpia-hn", "didehomes/bob", tmp_path)
+    config = DideConfiguration(r, mounts=[m], python_version=None)
+
+    res = batch._template_data_task_run("abcde", config)
     assert res["task_id"] == "abcde"
     assert res["task_id_1"] == "ab"
     assert res["task_id_2"] == "cde"
-    assert res["hipercow_root_drive"] == "Q:"
+    assert res["hipercow_root_drive"] == "V:"
     assert res["hipercow_root_path"] == "/my/project"
     assert (
-        res["network_shares_create"] == r"net use Q: \\wpia-hn\didehomes\bob /y"
+        res["network_shares_create"] == r"net use V: \\wpia-hn\didehomes\bob /y"
     )
-    assert res["network_shares_delete"] == "net use Q: /delete /y"
+    assert res["network_shares_delete"] == "net use V: /delete /y"
 
 
 def test_can_write_batch(tmp_path):
-    m = Mount("wpia-hn", "didehomes/bob", "/mnt/nethome")
-    path_map = PathMap(Path("some/path"), m, "Q:", "my/project")
+    path = tmp_path / "my/project"
+    root.init(path)
+    r = root.open_root(path)
+    m = Mount("wpia-hn", "didehomes/bob", tmp_path)
+    config = DideConfiguration(r, mounts=[m], python_version=None)
 
-    root.init(tmp_path)
-    r = root.open_root(tmp_path)
-    with transient_working_directory(tmp_path):
+    with transient_working_directory(path):
         tid = tc.task_create_shell(r, ["echo", "hello world"])
 
-    unc = batch.write_batch_task_run(tid, path_map, r)
+    unc = batch.write_batch_task_run(tid, config, r)
     path_rel = f"hipercow/py/tasks/{tid[:2]}/{tid[2:]}/task_run.bat"
     assert unc == f"//wpia-hn/didehomes/bob/my/project/{path_rel}"
     assert (r.path / path_rel).exists()
 
 
-def test_can_create_provision_data():
-    m = Mount("wpia-hn", "didehomes/bob", "/mnt/nethome")
-    path_map = PathMap(Path("some/path"), m, "Q:", "my/project")
-    res = batch._template_data_provision("env", "abcde", path_map)
+def test_can_create_provision_data(tmp_path):
+    path = tmp_path / "my/project"
+    root.init(path)
+    r = root.open_root(path)
+    m = Mount("wpia-hn", "didehomes/bob", tmp_path)
+    config = DideConfiguration(r, mounts=[m], python_version=None)
+
+    res = batch._template_data_provision("env", "abcde", config)
     assert res["environment_name"] == "env"
     assert res["provision_id"] == "abcde"
-    assert res["hipercow_root_drive"] == "Q:"
+    assert res["hipercow_root_drive"] == "V:"
     assert res["hipercow_root_path"] == "/my/project"
     assert (
-        res["network_shares_create"] == r"net use Q: \\wpia-hn\didehomes\bob /y"
+        res["network_shares_create"] == r"net use V: \\wpia-hn\didehomes\bob /y"
     )
-    assert res["network_shares_delete"] == "net use Q: /delete /y"
+    assert res["network_shares_delete"] == "net use V: /delete /y"
 
 
 def test_can_write_provision_batch(tmp_path):
-    m = Mount("wpia-hn", "didehomes/bob", "/mnt/nethome")
-    path_map = PathMap(Path("some/path"), m, "Q:", "my/project")
+    path = tmp_path / "my/project"
+    root.init(path)
+    r = root.open_root(path)
+    m = Mount("wpia-hn", "didehomes/bob", tmp_path)
+    config = DideConfiguration(r, mounts=[m], python_version=None)
 
-    root.init(tmp_path)
-    r = root.open_root(tmp_path)
-
-    unc = batch.write_batch_provision("myenv", "abcdef", path_map, r)
+    unc = batch.write_batch_provision("myenv", "abcdef", config, r)
     path_rel = "hipercow/py/env/myenv/provision/abcdef/run.bat"
     assert unc == f"//wpia-hn/didehomes/bob/my/project/{path_rel}"
     assert (r.path / path_rel).exists()

--- a/tests/dide/test_configure.py
+++ b/tests/dide/test_configure.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from hipercow import root
-from hipercow.configure import configure
+from hipercow.configure import configure, show_configuration
 from hipercow.dide.driver import DideConfiguration
 from hipercow.dide.mounts import Mount, remap_path
 from hipercow.dide.web import Credentials, DideWebClient
@@ -68,3 +68,21 @@ def test_provision_using_driver(tmp_path, mocker):
     assert mock_provision.mock_calls[0] == mock.call(
         r, "default", mock.ANY, path_map
     )
+
+
+def test_configure_python_version(tmp_path, mocker, capsys):
+    path = tmp_path / "a" / "b"
+    root.init(path)
+    r = root.open_root(path)
+    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
+    configure(r, "dide", python_version="3.12")
+    capsys.readouterr()
+    show_configuration(r)
+    out = capsys.readouterr().out
+    assert out == """Configuration for 'dide'
+path mapping:
+  drive: V:
+  share: \\\\projects\\other
+python version: 3.12
+"""

--- a/tests/dide/test_configure.py
+++ b/tests/dide/test_configure.py
@@ -18,12 +18,13 @@ def test_can_configure_dide_mount(tmp_path, mocker):
     r = root.open_root(path)
     mock_mounts = [Mount("projects", "other", tmp_path)]
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
-    configure(r, "dide")
+    configure(r, "dide", python_version=None)
 
     assert list_drivers(r) == ["dide"]
     driver = load_driver(r, "dide")
-    path_map = remap_path(path, mock_mounts)
-    assert driver.config == DideConfiguration(path_map)
+    assert driver.config == DideConfiguration(
+        r, mounts=mock_mounts, python_version=None
+    )
 
 
 def test_creating_task_triggers_submission(tmp_path, mocker):
@@ -38,7 +39,7 @@ def test_creating_task_triggers_submission(tmp_path, mocker):
         "hipercow.dide.driver.fetch_credentials", return_value=mock_creds
     )
     mocker.patch("hipercow.dide.driver.DideWebClient", mock_web_client)
-    configure(r, "dide")
+    configure(r, "dide", python_version=None)
     with transient_working_directory(path):
         tid = task_create_shell(r, ["echo", "hello world"])
 
@@ -61,7 +62,7 @@ def test_provision_using_driver(tmp_path, mocker):
     path_map = remap_path(path, mock_mounts)
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
     mocker.patch("hipercow.dide.driver._dide_provision", mock_provision)
-    configure(r, "dide")
+    configure(r, "dide", python_version=None)
     environment_new(r, "default", "pip")
     provision(r, "default", [])
     assert mock_provision.call_count == 1
@@ -80,9 +81,12 @@ def test_configure_python_version(tmp_path, mocker, capsys):
     capsys.readouterr()
     show_configuration(r)
     out = capsys.readouterr().out
-    assert out == """Configuration for 'dide'
+    assert (
+        out
+        == """Configuration for 'dide'
 path mapping:
   drive: V:
   share: \\\\projects\\other
 python version: 3.12
 """
+    )

--- a/tests/dide/test_configure.py
+++ b/tests/dide/test_configure.py
@@ -2,8 +2,8 @@ from unittest import mock
 
 from hipercow import root
 from hipercow.configure import configure, show_configuration
-from hipercow.dide.driver import DideConfiguration
-from hipercow.dide.mounts import Mount, remap_path
+from hipercow.dide.configuration import DideConfiguration
+from hipercow.dide.mounts import Mount
 from hipercow.dide.web import Credentials, DideWebClient
 from hipercow.driver import list_drivers, load_driver
 from hipercow.environment import environment_new
@@ -59,15 +59,15 @@ def test_provision_using_driver(tmp_path, mocker):
     r = root.open_root(path)
     mock_mounts = [Mount("projects", "other", tmp_path)]
     mock_provision = mock.MagicMock()
-    path_map = remap_path(path, mock_mounts)
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
     mocker.patch("hipercow.dide.driver._dide_provision", mock_provision)
     configure(r, "dide", python_version=None)
     environment_new(r, "default", "pip")
     provision(r, "default", [])
+    cfg = load_driver(r, None).config
     assert mock_provision.call_count == 1
     assert mock_provision.mock_calls[0] == mock.call(
-        r, "default", mock.ANY, path_map
+        r, "default", mock.ANY, cfg
     )
 
 

--- a/tests/dide/test_provision.py
+++ b/tests/dide/test_provision.py
@@ -4,6 +4,7 @@ from unittest import mock
 import hipercow.dide.driver
 from hipercow import root
 from hipercow.dide import mounts
+from hipercow.dide.configuration import DideConfiguration
 from hipercow.dide.driver import ProvisionWaitWrapper, _dide_provision
 from hipercow.dide.web import DideWebClient
 from hipercow.task import TaskStatus
@@ -22,8 +23,12 @@ def test_can_provision_with_dide(tmp_path, mocker):
     mock_client = mock.MagicMock(spec=DideWebClient)
     mocker.patch("hipercow.dide.driver._web_client", return_value=mock_client)
     mocker.patch("hipercow.dide.driver.taskwait")
+    mocker.patch(
+        "hipercow.dide.configuration.remap_path", return_value=path_map
+    )
+    config = DideConfiguration(r, mounts=[m], python_version=None)
 
-    _dide_provision(r, "myenv", "abcdef", path_map)
+    _dide_provision(r, "myenv", "abcdef", config)
 
     assert mock_client.submit.call_count == 1
     assert mock_client.mock_calls[0] == mock.call.submit(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,10 @@ def test_can_configure_driver(tmp_path):
         assert res.exit_code == 0
         assert res.output == "example\n"
 
+        res = runner.invoke(cli.cli_driver_show, [])
+        assert res.exit_code == 0
+        assert res.output == "Configuration for 'example'\n(no configuration)\n"
+
         res = runner.invoke(cli.cli_driver_unconfigure, ["example"])
         assert res.exit_code == 0
         assert res.output.strip() == "Removed configuration for 'example'"

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,7 +1,7 @@
 import pytest
 
 from hipercow import root
-from hipercow.configure import _write_configuration, configure, unconfigure
+from hipercow.configure import _write_configuration, configure, show_configuration, unconfigure
 from hipercow.driver import list_drivers, load_driver, load_driver_optional
 from hipercow.example import ExampleDriver
 
@@ -72,3 +72,30 @@ def test_get_default_driver(tmp_path):
     _write_configuration(r, b)
     with pytest.raises(Exception, match="More than one candidate driver"):
         load_driver(r, None)
+
+
+def test_can_show_configuration(tmp_path, capsys):
+    path = tmp_path / "ex"
+    root.init(path)
+    r = root.open_root(path)
+    configure(r, "example")
+    capsys.getouterr()
+    show_configuration(r)
+    out = capsys.getouterr().out
+    assert out == """Configuration for 'example'
+path mapping:
+  drive: V:
+  share: \\\\projects\\other
+python version: 3.12
+"""
+
+def test_can_show_configuration(tmp_path, capsys):
+    path = tmp_path / "ex"
+    root.init(path)
+    r = root.open_root(path)
+    configure(r, "example")
+    capsys.readouterr()
+    capsys.readouterr()
+    show_configuration(r, None)
+    out = capsys.readouterr().out
+    assert out == "Configuration for 'example'\n(no configuration)\n"

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,7 +1,12 @@
 import pytest
 
 from hipercow import root
-from hipercow.configure import _write_configuration, configure, show_configuration, unconfigure
+from hipercow.configure import (
+    _write_configuration,
+    configure,
+    show_configuration,
+    unconfigure,
+)
 from hipercow.driver import list_drivers, load_driver, load_driver_optional
 from hipercow.example import ExampleDriver
 
@@ -73,21 +78,6 @@ def test_get_default_driver(tmp_path):
     with pytest.raises(Exception, match="More than one candidate driver"):
         load_driver(r, None)
 
-
-def test_can_show_configuration(tmp_path, capsys):
-    path = tmp_path / "ex"
-    root.init(path)
-    r = root.open_root(path)
-    configure(r, "example")
-    capsys.getouterr()
-    show_configuration(r)
-    out = capsys.getouterr().out
-    assert out == """Configuration for 'example'
-path mapping:
-  drive: V:
-  share: \\\\projects\\other
-python version: 3.12
-"""
 
 def test_can_show_configuration(tmp_path, capsys):
     path = tmp_path / "ex"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,11 @@
 import os
+import platform
 from pathlib import Path
 
 import pytest
 
 from hipercow.util import (
+    check_python_version,
     find_file_descend,
     subprocess_run,
     transient_envvars,
@@ -76,3 +78,18 @@ def test_can_unset_envvars_if_none():
         assert os.environ.get("hc_a") == "1"
         assert "hc_b" not in os.environ
         assert os.environ.get("hc_c") == "3"
+
+
+def test_can_check_python_version():
+    ours3 = platform.python_version()
+    ours2 = ".".join(ours3.split(".")[:2])
+    assert check_python_version(None) == ours2
+    assert check_python_version(ours3) == ours2
+    assert check_python_version(ours2) == ours2
+    assert check_python_version("3.10") == "3.10"
+    assert check_python_version("3.11") == "3.11"
+    with pytest.raises(Exception, match="does not parse as a valid version"):
+        check_python_version("3.11a")
+    with pytest.raises(Exception, match="is not supported"):
+        check_python_version("3.9")
+    assert check_python_version("3.9", ["3.9", "3.10"]) == "3.9"


### PR DESCRIPTION
Not quite everything we need because it does not really let you configure this from the cli, but at the same time we can sort that out later.  The default behaviour will use the same python version as the user has, which is what we want most of the time really.

You should be able to do:

```
hipercow init .
hipercow driver configure dide
hipercow driver show
```

and then  see some useful diagnostics like

```
Configuration for 'dide'
path mapping:
  drive: Q:
  share: \\qdrive\homes/rfitzjoh
python version: 3.13
```

So, in this PR we have: 

* A new `driver show` sub command, and associated support (show_configuration)
* Separation of `DideConfiguration` from `DideDriver` so that I can reuse the configuration elsewhere
* Updates to the batch files to write out the version string
* Updates to the batch files to use the whole `DideConfiguration` object and not just the path mapping
* Associated test fallout

Coming later:

* We might change the bootstrap to install as `3.11` and not `311`
* We need to allow configuration to set the pyhthon version, but this is hard to do because the acceptable arguments vary by driver type and that's not easy to work with
* Get the valid set of python versions from the cluster itself
