### PR TITLE
Retrieve recent tasks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@
 
 site_name: hipercow
 site_url: https://mrc-ide.github.io/hipercow-py/
-repo_url: https://github.com/reside-ic/hipercow-py
+repo_url: https://github.com/mrc-ide/hipercow-py
 repo_name: mrc-ide/hipercow-py
 edit_uri: edit/main/docs/
 theme:

--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -15,8 +15,10 @@ from hipercow.environment import (
 from hipercow.provision import provision, provision_run
 from hipercow.task import (
     TaskStatus,
+    task_last,
     task_list,
     task_log,
+    task_recent,
     task_status,
     task_wait,
 )
@@ -113,6 +115,25 @@ def cli_task_list(with_status=None):
     with_status = _process_with_status(with_status)
     for task_id in task_list(r, with_status=with_status):
         click.echo(task_id)
+
+
+@task.command("last")
+def cli_task_last():
+    r = root.open_root()
+    task_id = task_last(r)
+    if task_id is None:
+        # set exit code
+        pass
+    else:
+        click.echo(task_id)
+
+
+@task.command("recent")
+@click.option("--limit", type=int)
+def cli_task_recent(limit: int):
+    r = root.open_root()
+    for i in task_recent(r, limit=limit):
+        click.echo(i)
 
 
 @task.command("create")

--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -122,7 +122,8 @@ def cli_task_last():
     r = root.open_root()
     task_id = task_last(r)
     if task_id is None:
-        # set exit code
+        # we might set exit code to something nonzero here, but this
+        # seems slightly hard...
         pass
     else:
         click.echo(task_id)

--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -19,6 +19,7 @@ from hipercow.task import (
     task_list,
     task_log,
     task_recent,
+    task_recent_rebuild,
     task_status,
     task_wait,
 )
@@ -131,8 +132,11 @@ def cli_task_last():
 
 @task.command("recent")
 @click.option("--limit", type=int)
-def cli_task_recent(limit: int):
+@click.option("--rebuild", is_flag=True)
+def cli_task_recent(limit: int, *, rebuild: bool):
     r = root.open_root()
+    if rebuild:
+        task_recent_rebuild(r, limit=limit)
     for i in task_recent(r, limit=limit):
         click.echo(i)
 

--- a/src/hipercow/root.py
+++ b/src/hipercow/root.py
@@ -58,6 +58,9 @@ class Root:
     def path_task_log(self, task_id: str) -> Path:
         return self.path_task(task_id) / "log"
 
+    def path_recent(self) -> Path:
+        return self.path_base() / "recent"
+
     def path_configuration(self, name: str | None) -> Path:
         hostname = platform.node()
         return self.path_base() / "config" / hostname / (name or ".")

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -231,4 +231,4 @@ def task_recent(root: Root, *, limit: int | None = None) -> list[str]:
 
 def task_last(root: Root) -> str | None:
     task_id = task_recent(root, limit=1)
-    return task_id[0] if task_id is not None else None
+    return task_id[0] if task_id else None

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -190,3 +190,45 @@ def task_wait(
     status = TaskStatus[result.status.upper()]
 
     return status == TaskStatus.SUCCESS
+
+
+def task_recent_rebuild(root: Root, *, limit: int | None = None) -> None:
+    path = root.path_recent()
+    if limit == 0:
+        if path.exists():
+            path.unlink()
+
+    ids = task_list(root)
+    time = [root.path_task_data(i).stat().st_ctime for i in ids]
+    ids = [i for _, i in sorted(zip(time, ids, strict=False))]
+
+    if limit is not None and limit > len(ids):
+        ids = ids[-limit:]
+
+    with path.open("w") as f:
+        for i in ids:
+            f.write(f"{i}\n")
+
+
+def task_recent(root: Root, *, limit: int | None = None) -> list[str]:
+    path = root.path_recent()
+    if not path.exists():
+        return []
+
+    with path.open() as f:
+        ids = [i.strip() for i in f.readlines()]
+
+    id_length = 32
+    if not all(len(i) == id_length for i in ids):
+        msg = "Recent data list is corrupt, please rebuild"
+        raise Exception(msg)
+
+    if limit is not None and limit < len(ids):
+        ids = ids[-limit:]
+
+    return ids
+
+
+def task_last(root: Root) -> str | None:
+    task_id = task_recent(root, limit=1)
+    return task_id[0] if task_id is not None else None

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -194,15 +194,16 @@ def task_wait(
 
 def task_recent_rebuild(root: Root, *, limit: int | None = None) -> None:
     path = root.path_recent()
-    if limit == 0:
+    if limit is not None and limit == 0:
         if path.exists():
             path.unlink()
+        return
 
     ids = task_list(root)
     time = [root.path_task_data(i).stat().st_ctime for i in ids]
     ids = [i for _, i in sorted(zip(time, ids, strict=False))]
 
-    if limit is not None and limit > len(ids):
+    if limit is not None and limit < len(ids):
         ids = ids[-limit:]
 
     with path.open("w") as f:

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -44,6 +44,8 @@ def _task_create(
     task_id = _new_task_id()
     environment = environment_check(root, environment)
     TaskData(task_id, method, data, str(path), environment, envvars).write(root)
+    with root.path_recent().open("a") as f:
+        f.write(f"{task_id}\n")
     _submit_maybe(task_id, driver, root)
     return task_id
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -207,8 +207,9 @@ def test_can_get_recent_tasks(tmp_path):
     root.init(tmp_path)
     r = root.open_root(tmp_path)
     with transient_working_directory(tmp_path):
-        ids = [tc.task_create_shell(r, ["echo", "hello world"])
-               for _ in range(5)]
+        ids = [
+            tc.task_create_shell(r, ["echo", "hello world"]) for _ in range(5)
+        ]
     assert task_last(r) == ids[4]
     assert task_recent(r) == ids
     assert task_recent(r, limit=3) == ids[2:]

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,3 +1,4 @@
+import time
 from unittest import mock
 
 import pytest
@@ -217,8 +218,11 @@ def test_can_detect_corrupt_recent_file(tmp_path):
     root.init(tmp_path)
     r = root.open_root(tmp_path)
     with transient_working_directory(tmp_path):
-        ids = [tc.task_create_shell(r, ["echo", "hello world"])
-               for _ in range(5)]
+        ids = []
+        for i in range(5):
+            if i > 0:
+                time.sleep(0.01)
+            ids.append(tc.task_create_shell(r, ["echo", "hello world"]))
     assert task_recent(r) == ids
     with r.path_recent().open("w") as f:
         for i in ids[:2] + [ids[2] + ids[3], ids[4]]:
@@ -229,5 +233,7 @@ def test_can_detect_corrupt_recent_file(tmp_path):
     assert task_recent(r) == ids
     task_recent_rebuild(r, limit=3)
     assert task_recent(r) == ids[2:]
+    task_recent_rebuild(r, limit=0)
+    assert task_recent(r) == []
     task_recent_rebuild(r, limit=0)
     assert task_recent(r) == []


### PR DESCRIPTION
Adds utilities for fetching the most recent tasks that have been submitted.  The tooling for doing this is very simple at the moment - there is a text file that we append to!  To cope with race conditions where multiple things write to the file at once we offer support to rebuild this file.  You can limit how many tasks are returned, though we'll want to expand this with "since" support soon.