### PR TITLE
Set up gitignore automatically

### DIFF
--- a/src/hipercow/root.py
+++ b/src/hipercow/root.py
@@ -24,6 +24,7 @@ def init(path: str | Path) -> None:
         raise Exception(msg)
 
     dest.mkdir(parents=True)
+    _add_gitignore(dest.parent)
     print(f"Initialised hipercow at {path}")
 
 
@@ -106,3 +107,10 @@ def open_root(path: None | str | Path = None) -> Root:
         msg = f"Failed to find 'hipercow' from {path}"
         raise Exception(msg)
     return Root(root)
+
+
+def _add_gitignore(path: Path):
+    dest = path / ".gitignore"
+    if not dest.exists():
+        with dest.open("w") as f:
+            f.write("*\n")

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -65,3 +65,24 @@ def test_error_if_no_root_found_by_descending(tmp_path):
     path = tmp_path / "a" / "b"
     with pytest.raises(Exception, match="Failed to find 'hipercow' from"):
         root.open_root(path)
+
+
+def test_create_gitignore_in_root(tmp_path):
+    path = tmp_path / "ex"
+    gi = path / "hipercow" / ".gitignore"
+    root.init(path)
+    assert gi.exists()
+    with gi.open() as f:
+        assert f.read() == "*\n"
+
+
+def test_dont_overwrite_existing_gitignore(tmp_path):
+    path = tmp_path / "ex"
+    gi = path / "hipercow" / ".gitignore"
+    (path / "hipercow").mkdir(parents=True)
+    with gi.open("w") as f:
+        f.write("hello!\n")
+    root.init(path)
+    assert gi.exists()
+    with gi.open() as f:
+        assert f.read() == "hello!\n"


### PR DESCRIPTION
I was writing docs about users needing to do this, but of course we can just do it automatically.  We should add the same logic to the R version too.

I've opted to put the file in hipercow/ not hipercow/py but could move it if we think it should by python specific