### PR TITLE
Add some docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: hatch run docs:build
+      - run: hatch run docs:build -s
       - name: Deploy to GitHub Pages
         if: github.event_name != 'pull_request'
         run: hatch env run -e docs -- mkdocs gh-deploy --force

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -4,10 +4,10 @@ We use the term "environment" to refer to the context in which a task runs, cont
 
 There are two key sorts of environments we (aim to) support:
 
-* [Python virtual environments](https://docs.python.org/3/tutorial/venv.html), generally installed via `pip`.  This is effectively a directory of installed python packages, plus some machinery to set the `PATH` environment variable (where the operating system looks for programmes) and the python search path (`sys.path`; where Python looks for packages).
+* [Python virtual environments](https://docs.python.org/3/tutorial/venv.html), generally installed via `pip`.  This is effectively a directory of installed python packages, plus some machinery to set the `PATH` environment variable (where the operating system looks for programs) and the python search path (`sys.path`: where Python looks for packages).
 * [Conda environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html), generally installed by `conda`, `miniconda`, `mamba` or `micromamba`.  This is a framework popular in bioinformatics and can be used to create a self-consistent installation of a great many tools, isolated from system libraries.
 
-Environments are necessary because we aim to support the minimum useful number of globally installed software on the cluster.  This reduces the number of times you have to wait for someone else to install or update some piece of software that you depend on for your work.
+Environments are necessary because we aim to keep globally installed software on the cluster to a minimum.  This reduces the number of times you have to wait for someone else to install or update some piece of software that you depend on for your work.
 
 ## In a nutshell
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,28 @@
+# Environments
+
+We use the term "environment" to refer to the context in which a task runs, containing the programs and code it is able to find.  It is not quite the same as [the R `hipercow` concept](https://mrc-ide.github.io/hipercow/articles/environments.html) which considers the execution environment of an R expression, because of the way that Python code is typically run.
+
+There are two key sorts of environments we (aim to) support:
+
+* [Python virtual environments](https://docs.python.org/3/tutorial/venv.html), generally installed via `pip`.  This is effectively a directory of installed python packages, plus some machinery to set the `PATH` environment variable (where the operating system looks for programmes) and the python search path (`sys.path`; where Python looks for packages).
+* [Conda environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html), generally installed by `conda`, `miniconda`, `mamba` or `micromamba`.  This is a framework popular in bioinformatics and can be used to create a self-consistent installation of a great many tools, isolated from system libraries.
+
+Environments are necessary because we aim to support the minimum useful number of globally installed software on the cluster.  This reduces the number of times you have to wait for someone else to install or update some piece of software that you depend on for your work.
+
+## In a nutshell
+
+The basic approach for working with environments is:
+
+1. Tell `hipercow` the sort of environment you want to work with, and what it is called
+2. Install things into that environment (this is launched from your computer but runs on the cluster)
+3. Run a task that uses your environment
+
+```
+$ hipercow environment new
+$ hipercow environment provision
+$ hipercow task create mytool
+```
+
+## Multiple environments
+
+You can have multiple environments configured within a single `hipercow` root.  This is intended to let you work with a workflow where you need incompatible sets of conda tools, or some jobs with conda and others with pip.  It is not expected that this will be wildly useful to many people and you can generally ignore the existence of this and consider `hipercow environment new` to be simply the way that you plan on configuring a single environment.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -23,6 +23,85 @@ $ hipercow environment provision
 $ hipercow task create mytool
 ```
 
+You must have a driver configured (e.g., by running `hipercow driver configure dide`) in order to provision an environment.
+
+## Default environments
+
+You always have an environment called `empty`, which contains nothing.  This can run shell commands on the cluster, but without referencing any interesting software.  In the unlikely event that you have a python package that does not need any non-default packages this is all you need.  You cannot install anything else into this environment.
+
+```command
+$ hipercow environment list
+empty
+```
+
+You can initialise a more interesting environment using `new`, this will by default initialise the environment `default` using the `pip` engine:
+
+```command
+$ hipercow environment new
+Creating environment 'default' using 'pip'
+```
+
+## Provisioning an environment with `pip`
+
+To provision an environment, use `hipercow environment provision`; this runs on the cluster and installs the packages you need to run your tasks.  This is needed because the cluster cannot see the packages you have installed locally, and the cluster nodes might be a different operating system type to your computer anyway.  You can install packages automatically or manually.
+
+**The automatic installation** will get better over time, but we hope this is enough to get at least some people going.  The rules are:
+
+* If `pyproject.toml` exists, we try and install the project using `pip install .`
+* If `requirements.txt` exists, we try and install from that using `pip install -r requirements.txt`
+* Otherwise we error.
+
+If your project has either `pyproject.toml` or `requirements.txt`, hopefully you can just run
+
+```command
+$ hipercow environment provision
+```
+
+which will set up the `default` environment with the packages that you need.
+
+There are lots of ways we could improve this in future, for example:
+
+* Allow switching the environment from `pyproject.toml`
+* Selection of groups of optional packages to install
+* Multiple installation steps
+* Attempt to install a project in editable mode
+
+Please let us know if you have ideas on how this could be improved.
+
+**The manual installation** is very simple; provide a command that calls `pip` and we'll run it on the cluster.
+
+For example, suppose you need a couple of extra packages:
+
+```command
+$ hipercow environment provision pip install cowsay fortune-python
+```
+
+and now both the `cowsay` and `fortune` packages (and command line interfaces) are available.
+
 ## Multiple environments
 
 You can have multiple environments configured within a single `hipercow` root.  This is intended to let you work with a workflow where you need incompatible sets of conda tools, or some jobs with conda and others with pip.  It is not expected that this will be wildly useful to many people and you can generally ignore the existence of this and consider `hipercow environment new` to be simply the way that you plan on configuring a single environment.
+
+You can run
+
+```command
+$ hipercow environment create --name dev
+```
+
+to create a new `dev` environment.  You can provision this the same way as above, but passing `--name dev` through to `provision`
+
+```command
+$ hipercow environment provision --name dev pip install <packages...>
+```
+
+and then when submitting tasks use the `--environment` option to select the environment:
+
+```command
+$ hipercow task create --environment dev <your command here>
+```
+
+Possible use cases of this functionality are:
+
+* trying out a different version of a package side-by-side with a previous installation to compare results
+* installing an update without disrupting tasks that are already queued up
+* mixing `pip`- and `conda`-based environments in one project (once the latter are supported)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# hipercow
+# `hipercow`
 
-This is a package for interfacing with the DIDE cluster directly from Python.  It is related to the [R package of the same name](https://mrc-ide.github.io/hipercow/) but with a focus on working with Python or other cli jobs.
+This is a package for interfacing with the DIDE cluster directly from Python.  It is related to the [R package of the same name](https://mrc-ide.github.io/hipercow/) but with a focus on working with Python or other commandline-based jobs.
 
 ## Installation
 
@@ -19,5 +19,5 @@ pip install git+https://github.com/mrc-ide/hipercow-py
 You have several basic options to install:
 
 1. Install into a virtual environment along with everything else
-2. Install as a standalone tool with [pipx](https://pipx.pypa.io/stable/) so that `hipercow` is globally available but not part of your project dependencies
+2. Install as a standalone tool with [`pipx`](https://pipx.pypa.io/stable/) so that `hipercow` is globally available but not part of your project dependencies
 3. Install globally with `pip` (not recommended)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,23 @@
 # hipercow
 
 This is a package for interfacing with the DIDE cluster directly from Python.  It is related to the [R package of the same name](https://mrc-ide.github.io/hipercow/) but with a focus on working with Python or other cli jobs.
+
+## Installation
+
+Installation will soon work through `pip`, with
+
+```sh
+pip install hipercow
+```
+
+in the meantime you can install from GitHub with
+
+```sh
+pip install git+https://github.com/mrc-ide/hipercow-py
+```
+
+You have several basic options to install:
+
+1. Install into a virtual environment along with everything else
+2. Install as a standalone tool with [pipx](https://pipx.pypa.io/stable/) so that `hipercow` is globally available but not part of your project dependencies
+3. Install globally with `pip` (not recommended)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,18 +1,18 @@
 # Introduction
 
-This section will describe running a simple task on the cluster, using `hipercow`.  We make some assuptions, common to the [R version](https://mrc-ide.github.io/hipercow/):
+This section will describe running a simple task on the cluster, using `hipercow`.  We make some assumptions, common to the [R version](https://mrc-ide.github.io/hipercow/):
 
 * You are a member of DIDE at Imperial College London
 * You have an account on our cluster; you can check this by logging into [the web portal](https://mrcdata.dide.ic.ac.uk/hpc) with your [DIDE credentials](https://mrc-ide.github.io/hipercow/articles/windows.html#about-our-usernames-and-passwords).  If you cannot log in, please email Wes.
 * You are working in a network share that the cluster can see. Ideally this is a **project share** and not your network home directory, as project shares are much faster and more reliable.  See the [R documentation](https://mrc-ide.github.io/hipercow/articles/windows.html#filesystems-and-paths) for more on this topic, including how to configure this on your machine
 * You have some Python code that you would like to run on the cluster, which currently works for you locally.
-* You are confident excecuting commands at the command line (bash or similar). If you are not, please do talk with us as we'd be interested in your workflows.
+* You are confident executing commands at the command line (bash or similar). If you are not, please do talk with us as we'd be interested in your workflows.
 
-We also make the assumption that you are ok with some rough edges while we develop this system.  Please be prepared to work with us to track down and understand the bugs that you will definitely run into, so that we can make this tool work for people as well as the R package does.
+We also make the assumption that you are OK with some rough edges while we develop this system.  Please be prepared to work with us to track down and understand the bugs that you will definitely run into, so that we can make this tool work for people as well as the R package does.
 
 ## Project layout
 
-You may have an existing project, or you might be starting from scratch.  We are not at all prescriptive about how you might structure your files, but we will create a directory `hipercow/` at the root of your project, and you must not manually change or delete any file within that directory.  It is safe to mix R and Python hipercows within the same project but at the moment they are [completely unaware of each others existence despite occupying the same space](https://en.wikipedia.org/wiki/The_City_%26_the_City).  It is likely that you will have a `pyproject.toml` or a `requirements.txt` file at this level, and quite possibly your `.git/` directory.
+You may have an existing project, or you might be starting from scratch.  We are not at all prescriptive about how you might structure your files, but we will create a directory `hipercow/` at the root of your project, and you must not manually change or delete any file within that directory.  It is safe to mix R and Python `hipercow`s within the same project but at the moment they are [completely unaware of each others existence despite occupying the same space](https://en.wikipedia.org/wiki/The_City_%26_the_City).  It is likely that you will have a `pyproject.toml` or a `requirements.txt` file at this level, and quite possibly your `.git/` directory.
 
 ## Interaction with `hipercow`
 
@@ -32,6 +32,52 @@ Commands:
   environment
   init
   task
+```
+
+## Authentication
+
+Before starting anything, we should sort out your DIDE credentials.  You need your DIDE username and password - the password might differ from your ICT password, see [our guide to passwords](https://mrc-ide.github.io/hipercow/articles/windows.html#about-our-usernames-and-passwords).  If unsure, you can check by logging into [the web portal](https://mrcdata.dide.ic.ac.uk/hpc).
+
+You can run `hipercow dide authenticate` to store credentials in your system keychain.
+
+```console
+$ hipercow dide authenticate
+# Please enter your DIDE credentials
+
+We need to know your DIDE username and password in order to log you into
+the cluster. This will be shared across all projects on this machine, with
+the username and password stored securely in your system keychain. You will
+have to run this command again on other computers
+
+Your DIDE password may differ from your Imperial password, and in some
+cases your username may also differ. If in doubt, perhaps try logging in
+at https://mrcdata.dide.ic.ac.uk/hpc" and use the combination that works
+for you there.
+
+DIDE username (default: rfitzjoh) >
+Using username 'rfitzjoh'
+
+Password:
+I am going to to try and log in with your password now.
+If this fails we can always try again
+
+Success! I'm saving these into your keyring now so that we can reuse these
+when we need to log into the cluster.
+```
+
+At any point you can check credentials by running
+
+```console
+$ hipercow dide authenticate --check
+Fetching credentials
+Testing credentials
+Success!
+```
+
+and you can delete them by running
+
+```console
+$ hipercow dide authenticate --clear
 ```
 
 ## Initialisation
@@ -63,7 +109,7 @@ Waiting......OK
 hello hipercow world
 ```
 
-The `--wait` option should occur before your command and indicates that hipercow should wait for the task to complete before returning.  The string printed out (`a182aa2b169c2e04aa0a5d27fff1acaa`) is the "task id" - every task gets one of these and they are unique.
+The `--wait` option should occur before your command and indicates that `hipercow` should wait for the task to complete before returning.  The string printed out (`a182aa2b169c2e04aa0a5d27fff1acaa`) is the "task id" - every task gets one of these and they are unique.
 
 ## Running some python code
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -12,7 +12,7 @@ We also make the assumption that you are OK with some rough edges while we devel
 
 ## Project layout
 
-You may have an existing project, or you might be starting from scratch.  We are not at all prescriptive about how you might structure your files, but we will create a directory `hipercow/` at the root of your project, and you must not manually change or delete any file within that directory.  It is safe to mix R and Python `hipercow`s within the same project but at the moment they are [completely unaware of each others existence despite occupying the same space](https://en.wikipedia.org/wiki/The_City_%26_the_City).  It is likely that you will have a `pyproject.toml` or a `requirements.txt` file at this level, and quite possibly your `.git/` directory.
+You may have an existing project, or you might be starting from scratch.  We are not at all prescriptive about how you might structure your files, but we will create a directory `hipercow/` at the root of your project, and you must not manually change or delete any file within that directory.  It is safe to mix R and Python `hipercow`s within the same project but at the moment they are [completely unaware of each other's existence despite occupying the same space](https://en.wikipedia.org/wiki/The_City_%26_the_City).  It is likely that you will have a `pyproject.toml` or a `requirements.txt` file at this level, and quite possibly your `.git/` directory.
 
 ## Interaction with `hipercow`
 

--- a/docs/known-words.txt
+++ b/docs/known-words.txt
@@ -1,3 +1,8 @@
+bioinformatics
+conda
 commandline
 keychain
+pythonic
+roadmap
+stacktrace
 wes

--- a/docs/known-words.txt
+++ b/docs/known-words.txt
@@ -1,0 +1,3 @@
+commandline
+keychain
+wes

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,3 +25,5 @@ There are also many rough edges:
 
 * The way that progress and messages are printed out is spartan at best, and a far cry from our standard use of the [`cli` R package](https://github.com/r-lib/cli)
 * If an error is thrown, you will see a gory stacktrace
+* The provisioning is pretty basic
+* Not all error output make it from the cluster back to your screen

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,27 @@
+# Roadmap
+
+## For users of the R `hipercow`
+
+This package will feel quite different to the R version of `hipercow`; our aim here is to provide a somewhat [Pythonic](https://blog.startifact.com/posts/what-is-pythonic/) interface to the cluster that takes the best *ideas* from the R version without directly implementing the same API.  The two packages currently share the same name but do not yet interact directly -- this may change in future as they develop,
+
+The most obvious difference at the moment is that all interaction with the python version occurs via the command line interface.  We have started here because it seems far less common to use the [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) from Python than it does in R.  This change has many positives; it makes running arbitrary programs (e.g., python packages with commandline interfaces, bioinformatics tools, etc) very straightforward, so long as they can be found.
+
+## Missing features
+
+Many of these are features that will feel familiar to users of the R version.
+
+* The concept of "resources" for a task (e.g., the number of cores etc).  This will likely be added soon.
+* Running functions, or expressions of python code, without writing it out as a file.  This requires thoughts and opinions about interface and we welcome feedback and ideas.
+* Running many related tasks at once and interacting with this bundle.  We do not know what the easiest interface for this looks like and welcome ideas and feedback.
+* The ["worker" patterns](https://mrc-ide.github.io/hipercow/articles/workers.html) for a faster, less persistent, queue.
+* Review the effect of a series of attempts to install packages
+* Retry failed tasks
+* Support multiple mounted windows shares at once
+* Run on our new Linux cluster
+* Retrieve information about the cluster that you are running on
+* Support for setting up [conda environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html), particularly to support bioinformatics workflows.
+
+There are also many rough edges:
+
+* The way that progress and messages are printed out is spartan at best, and a far cry from our standard use of the [`cli` R package](https://github.com/r-lib/cli)
+* If an error is thrown, you will see a gory stacktrace

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,3 +41,9 @@ theme:
 plugins:
 - search
 - mkdocstrings
+- spellcheck:
+    backends:
+    - symspellpy
+    - codespell:
+        dictionaries: [clear, rare]
+    known_words: known-words.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,8 @@ theme:
     repo: fontawesome/brands/github
   features:
     - content.action.edit
+    - content.code.copy
+    - content.code.annotate
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,9 +189,10 @@ explicit-only = [
 [tool.hatch.envs.docs]
 extra-dependencies = [
   "mkdocs-material",
+  "mkdocs-spellcheck[all]",
   "mkdocstrings-python",
 ]
 
 [tool.hatch.envs.docs.scripts]
-build = "mkdocs build"
-serve = "mkdocs serve"
+build = "mkdocs build {args}"
+serve = "mkdocs serve {args}"

--- a/src/hipercow/environment.py
+++ b/src/hipercow/environment.py
@@ -76,8 +76,8 @@ def environment_delete(root: Root, name: str) -> None:
 
 def environment_check(root: Root, name: str | None) -> str:
     if name is None:
-        return "default"
-    if name in {"empty", "default"} or environment_exists(root, name):
+        return "default" if environment_exists(root, "default") else "empty"
+    if name == "empty" or environment_exists(root, name):
         return name
     msg = f"No such environment '{name}'"
     raise Exception(msg)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -27,8 +27,9 @@ def test_environment_selection(tmp_path):
     root.init(tmp_path)
     r = root.open_root(tmp_path)
     assert environment_check(r, "empty") == "empty"
-    assert environment_check(r, None) == "default"
-    assert environment_check(r, "default") == "default"
+    assert environment_check(r, None) == "empty"
+    with pytest.raises(Exception, match="No such environment 'default'"):
+        environment_check(r, "default")
     with pytest.raises(Exception, match="No such environment 'other'"):
         environment_check(r, "other")
 


### PR DESCRIPTION
This PR adds the beginnings of basic docs. We might end up generating some of these with quarto in the end because I don't love just copying in random commands and hoping they stay correct.

I've written up the beginnings of a guide to the design of the tools, provisioning, dealing with environments, etc.  It's enough that hopefully someone could get started with things.

I have added in a spell check, and set (via `-s`) strict mode for building on CI which fails if spelling errors are found.

I also simplified the logic around empty/default a bit, and I think I'm happier with this.

In the meantime I notice I have broken the bootstrap (the #30 PR breaks paths and the bootstrap needs updating).  I'll sort that out next but in the meantime be aware that code here does not work with the current main.  I want to sort the bootstrap properly though.