### PR TITLE
Start on docs

### DIFF
--- a/docs/known-words.txt
+++ b/docs/known-words.txt
@@ -5,6 +5,7 @@ dide
 entrypoint
 eval
 hipercow
+installable
 keychain
 pythonic
 roadmap

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_url: https://mrc-ide.github.io/hipercow-py/
 repo_url: https://github.com/mrc-ide/hipercow-py
 repo_name: mrc-ide/hipercow-py
 edit_uri: edit/main/docs/
+
 theme:
   name: material
   icon:
@@ -14,6 +15,7 @@ theme:
     - content.action.edit
     - content.code.copy
     - content.code.annotate
+    - toc.follow
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"
@@ -40,7 +42,43 @@ theme:
 
 plugins:
 - search
-- mkdocstrings
+- autorefs
+- mkdocstrings:
+    default_handler: python
+    handlers:
+      python:
+        inventories:
+        - https://docs.python.org/3/objects.inv
+        paths: [src]
+        options:
+          docstring_style: google
+          show_symbol_type_heading: true
+          show_symbol_type_toc: true
+          show_root_heading: true
+          show_source: false
+          # show_signature_annotations: true
+          signature_crossrefs: true
+          docstring_section_style: list
+    # handlers:
+    #   python:
+    #     paths: [src]
+    #     options:
+    #       docstring_options:
+    #         # ignore_init_summary: true
+    #         docstring_style: google
+    #       # docstring_section_style: list
+    #       # filters: ["!^_"]
+    #       # heading_level: 2
+    #       # inherited_members: true
+    #       # merge_init_into_class: true
+    #       # parameter_headings: true
+    #       # separate_signature: true
+    #       # show_root_full_path: false
+    #       # show_signature_annotations: true
+
+    #       # signature_crossrefs: true
+    #       # summary: true
+
 - spellcheck:
     backends:
     - symspellpy
@@ -52,3 +90,4 @@ plugins:
 markdown_extensions:
   - attr_list
   - mkdocs-click
+  - pymdownx.magiclink

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,28 +56,10 @@ plugins:
           show_symbol_type_toc: true
           show_root_heading: true
           show_source: false
+          # This makes things quite noisy I think:
           # show_signature_annotations: true
           signature_crossrefs: true
           docstring_section_style: list
-    # handlers:
-    #   python:
-    #     paths: [src]
-    #     options:
-    #       docstring_options:
-    #         # ignore_init_summary: true
-    #         docstring_style: google
-    #       # docstring_section_style: list
-    #       # filters: ["!^_"]
-    #       # heading_level: 2
-    #       # inherited_members: true
-    #       # merge_init_into_class: true
-    #       # parameter_headings: true
-    #       # separate_signature: true
-    #       # show_root_full_path: false
-    #       # show_signature_annotations: true
-
-    #       # signature_crossrefs: true
-    #       # summary: true
 
 - spellcheck:
     backends:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ ignore = [
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
   # Don't require docstrings everywhere for now
-  "D100", "D101", "D102", "D103", "D104", "D105",
+  "D100", "D101", "D102", "D103", "D104", "D105", "D107",
   # Ignore shadowing
   "A001", "A002", "A003",
   # Allow pickle
@@ -178,7 +178,7 @@ unfixable = [
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.ruff.lint.pydocstyle]
-convention = "numpy"
+convention = "google"
 
 [tool.pytest.ini_options]
 markers = [

--- a/src/hipercow/configure.py
+++ b/src/hipercow/configure.py
@@ -20,7 +20,7 @@ def configure(name: str, *, root: OptionalRoot = None, **kwargs) -> None:
     Args:
         name: The name of the driver.  This will be `dide` unless you
             are developing `hipercow` itself :)
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
         **kwargs (Any): Arguments passed to, and supported by, your driver.
 
     Returns:
@@ -39,7 +39,7 @@ def unconfigure(name: str, root: OptionalRoot = None) -> None:
     Args:
         name: The name of the driver.  This will be `dide` unless you
             are developing `hipercow` itself :)
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         Nothing, called for side effects only.
@@ -63,7 +63,7 @@ def show_configuration(
     Args:
         name: The name of the driver.  This will be `dide` unless you
             are developing `hipercow` itself :)
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         Nothing, called for side effects only.

--- a/src/hipercow/configure.py
+++ b/src/hipercow/configure.py
@@ -13,6 +13,19 @@ from hipercow.util import transient_working_directory
 # * https://docs.pytest.org/en/stable/how-to/writing_plugins.html#pip-installable-plugins
 # * https://packaging.python.org/en/latest/specifications/entry-points/
 def configure(name: str, *, root: OptionalRoot = None, **kwargs) -> None:
+    """Configure a driver.
+
+    Configures a `hipercow` root to use a driver.
+
+    Args:
+        name: The name of the driver.  This will be `dide` unless you
+            are developing `hipercow` itself :)
+        root: The root, or if given search from the current directory.
+        **kwargs (Any): Arguments passed to, and supported by, your driver.
+
+    Returns:
+        Nothing, called for side effects only.
+    """
     root = open_root(root)
     driver = _get_driver(name)
     with transient_working_directory(root.path):
@@ -21,6 +34,16 @@ def configure(name: str, *, root: OptionalRoot = None, **kwargs) -> None:
 
 
 def unconfigure(name: str, root: OptionalRoot = None) -> None:
+    """Unconfigure (remove) a driver.
+
+    Args:
+        name: The name of the driver.  This will be `dide` unless you
+            are developing `hipercow` itself :)
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        Nothing, called for side effects only.
+    """
     root = open_root(root)
     path = root.path_configuration(name)
     if path.exists():
@@ -33,10 +56,20 @@ def unconfigure(name: str, root: OptionalRoot = None) -> None:
 
 
 def show_configuration(
-    driver: str | None = None, root: OptionalRoot = None
+    name: str | None = None, root: OptionalRoot = None
 ) -> None:
+    """Show a driver configuration.
+
+    Args:
+        name: The name of the driver.  This will be `dide` unless you
+            are developing `hipercow` itself :)
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        Nothing, called for side effects only.
+    """
     root = open_root(root)
-    dr = load_driver(driver, root)
+    dr = load_driver(name, root)
     print(f"Configuration for '{dr.name}'")
     dr.show_configuration()
 

--- a/src/hipercow/environment.py
+++ b/src/hipercow/environment.py
@@ -33,6 +33,27 @@ class EnvironmentConfiguration:
 # actually create the environment, just the definition of that
 # environment.
 def environment_new(name: str, engine: str, root: OptionalRoot = None) -> None:
+    """Create a new environment.
+
+    Creating an environment selects a name and declares the engine for
+    the environment.  After doing this, you will certainly want to
+    provision the environment using `provision()`.
+
+    Args:
+        name: The name for the environment.  The name `default` is a
+            good choice if you only want a single environment, as this
+            is the environment used by default.  You cannot use
+            `empty` as that is a special empty environment.
+
+        engine: The environment engine to use.  The options here are
+            `pip` and `empty`.  Soon we will support `conda` too.
+
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        Nothing, called for side effects.
+
+    """
     root = open_root(root)
     path = root.path_environment(name)
 
@@ -50,6 +71,16 @@ def environment_new(name: str, engine: str, root: OptionalRoot = None) -> None:
 
 
 def environment_list(root: OptionalRoot = None) -> list[str]:
+    """List known environments.
+
+    Args:
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        A sorted list of environment names.  The name `empty` will
+            always be present.
+
+    """
     root = open_root(root)
     special = ["empty"]
     path = root.path_environment(None)
@@ -58,6 +89,15 @@ def environment_list(root: OptionalRoot = None) -> list[str]:
 
 
 def environment_delete(name: str, root: OptionalRoot = None) -> None:
+    """Delete an environment.
+
+    Args:
+        name: The name of the environment to delete.
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        Nothing, called for side effects only.
+    """
     root = open_root(root)
     if name == "empty":
         msg = "Can't delete the empty environment"
@@ -78,6 +118,22 @@ def environment_delete(name: str, root: OptionalRoot = None) -> None:
 
 
 def environment_check(name: str | None, root: OptionalRoot = None) -> str:
+    """Validate an environment name for this root.
+
+    This function can be used to ensure that `name` is a reasonable
+    environment name to use in your root.  It returns the resolved
+    name (selecting between `empty` and `default` if `name` is
+    `None`), and errors if the requested environment is not found.
+
+    Args:
+        name: The name of the environment to use, or `None` to select
+            the appropriate default.
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        The resolved environment name.
+
+    """
     root = open_root(root)
     if name is None:
         return "default" if environment_exists("default", root) else "empty"
@@ -88,10 +144,25 @@ def environment_check(name: str | None, root: OptionalRoot = None) -> str:
 
 
 def environment_exists(name: str, root: OptionalRoot = None) -> bool:
+    """Check if an environment exists.
+
+    Note that this function will return `False` for `empty`, even
+    though `empty` is always a valid choice.  We might change this in
+    future.
+
+    Args:
+        name: The name of the environment to check.
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        `True` if the environment exist, otherwise `False`.
+
+    """
     root = open_root(root)
     return root.path_environment(name).exists()
 
 
+# TODO: move this somewhere less user-facing
 def environment_engine(name: str, root: Root) -> EnvironmentEngine:
     use_empty_environment = name == "empty" or (
         name == "default" and not environment_exists(name, root)

--- a/src/hipercow/environment.py
+++ b/src/hipercow/environment.py
@@ -48,7 +48,7 @@ def environment_new(name: str, engine: str, root: OptionalRoot = None) -> None:
         engine: The environment engine to use.  The options here are
             `pip` and `empty`.  Soon we will support `conda` too.
 
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         Nothing, called for side effects.
@@ -74,7 +74,7 @@ def environment_list(root: OptionalRoot = None) -> list[str]:
     """List known environments.
 
     Args:
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         A sorted list of environment names.  The name `empty` will
@@ -93,7 +93,7 @@ def environment_delete(name: str, root: OptionalRoot = None) -> None:
 
     Args:
         name: The name of the environment to delete.
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         Nothing, called for side effects only.
@@ -128,7 +128,7 @@ def environment_check(name: str | None, root: OptionalRoot = None) -> str:
     Args:
         name: The name of the environment to use, or `None` to select
             the appropriate default.
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         The resolved environment name.
@@ -152,10 +152,10 @@ def environment_exists(name: str, root: OptionalRoot = None) -> bool:
 
     Args:
         name: The name of the environment to check.
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
-        `True` if the environment exist, otherwise `False`.
+        `True` if the environment exists, otherwise `False`.
 
     """
     root = open_root(root)

--- a/src/hipercow/provision.py
+++ b/src/hipercow/provision.py
@@ -66,7 +66,36 @@ def provision(
     *,
     driver: str | None = None,
     root: OptionalRoot = None,
-):
+) -> None:
+    """Provision an environment.
+
+    This function requires that your root has a driver configured
+    (with `hipercow.configure`) and an environment created (with
+    `hipercow.environment_new`).
+
+    Note that in the commandline tool, this command is grouped into
+    the `environment` group; we may move this function into the
+    `environment` module in future.
+
+    Args:
+        name: The name of the environment to provision
+
+        cmd: Optionally the command to run to do the provisioning. If
+            `None` then the environment engine will select an
+            appropriate command if it is well defined for your setup.
+            The details here depend on the engine.
+
+        driver: The name of the driver to use in provisioning.
+            Normally this can be omitted, as `None` (the default) will
+            select your driver automatically if only one is
+            configured.
+
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        Nothing, called for side effects only.
+
+    """
     root = open_root(root)
     path_config = root.path_environment_config(name)
     if not path_config.exists():

--- a/src/hipercow/provision.py
+++ b/src/hipercow/provision.py
@@ -90,7 +90,7 @@ def provision(
             select your driver automatically if only one is
             configured.
 
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         Nothing, called for side effects only.

--- a/src/hipercow/root.py
+++ b/src/hipercow/root.py
@@ -1,3 +1,5 @@
+"""Interact with the hipercow root."""
+
 import platform
 from pathlib import Path
 from typing import TypeAlias
@@ -6,6 +8,22 @@ from hipercow.util import find_file_descend
 
 
 def init(path: str | Path) -> None:
+    """Initialise a hipercow root.
+
+    Sets up a new hipercow root at `path`, creating the directory
+    `<path>/hipercow/` which will contain all of hipercow's files.  It
+    is safe to re-initialise an already-created hipercow root (in
+    which case nothing happens) and safe to initialise a *Python*
+    hipercow root at the same location as an R one, though at the
+    moment they do not interact.
+
+    Args:
+        path: The path to the project root
+
+    Returns:
+        Nothing, called for side effects only.
+
+    """
     path = Path(path)
     dest = path / "hipercow" / "py"
 
@@ -103,9 +121,36 @@ class Root:
 
 
 OptionalRoot: TypeAlias = None | str | Path | Root
+"""Optional root type, for user-facing functions.
+
+Represents different inputs to the user-facing functions in hipercow,
+recognising that most of the time the working directory will be within
+a hipercow environment.  The possible types represent different
+possibilities:
+
+* `None`: search for the root from the current directory (like `git` does)
+* `str`: the name of a path to search from
+* `Path`: a `pathlib.Path` object representing the path to search from
+* `Root`: a root previously opened with [`open_root`][hipercow.root.open_root]
+
+"""
 
 
 def open_root(path: OptionalRoot = None) -> Root:
+    """Open a hipercow root.
+
+    Locate and validate a hipercow root, converting an `OptionalRoot` type
+    into a real `Root` object.  This function is used in most user-facing
+    functions in hipercow, but you can call it yourself to validate the
+    root early.
+
+    Args:
+        path: A path to the root to open, a `Root`, or `None`.
+
+    Returns:
+        The opened `Root` object.
+
+    """
     if isinstance(path, Root):
         return path
     root = find_file_descend("hipercow", path or Path.cwd())

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -1,3 +1,5 @@
+"""Functions for interacting with tasks."""
+
 import pickle
 from dataclasses import dataclass
 from enum import Flag, auto
@@ -9,6 +11,21 @@ from hipercow.util import file_create
 
 
 class TaskStatus(Flag):
+    """Status of a task.
+
+    Tasks move from `CREATED` to `SUBMITTED` to `RUNNING` to one of
+    `SUCCESS` or `FAILURE`.  In addition a task might be `CANCELLED`
+    (this could happen from `CREATED`, `SUBMITTED` or `RUNNING`) or
+    might be `MISSING` if it does not exist.
+
+    A runnable  task is  one that  we could  use `task_eval`  with; it
+    might be `CREATED` or `SUBMITTED`.
+
+    A terminal task is one that has reached the latest state it will
+    reach, and is `SUCCESS`, `FAILURE` or `CANCELLED`.
+
+    """
+
     CREATED = auto()
     SUBMITTED = auto()
     RUNNING = auto()
@@ -20,9 +37,11 @@ class TaskStatus(Flag):
     RUNNABLE = CREATED | SUBMITTED
 
     def is_runnable(self) -> bool:
+        """Check if a status implies a task can be run."""
         return bool(self & TaskStatus.RUNNABLE)
 
     def is_terminal(self) -> bool:
+        """Check if a status implies a task is completed."""
         return bool(self & TaskStatus.TERMINAL)
 
     def __str__(self) -> str:
@@ -68,11 +87,32 @@ class TaskTimes:
 
 
 def task_exists(task_id: str, root: OptionalRoot = None) -> bool:
+    """Test if a task exists.
+
+    A task exists if the `task_id` was used with this hipercow root
+    (i.e., if any files associated with it exist).
+
+    Args:
+        task_id: The task identifier, a 32-character hex string.
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        `True` if the task exists.
+    """
     root = open_root(root)
     return root.path_task(task_id).exists()
 
 
 def task_status(task_id: str, root: OptionalRoot = None) -> TaskStatus:
+    """Read task status.
+
+    Args:
+        task_id: The task identifier to check, a 32-character hex string.
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        The status of the task.
+    """
     root = open_root(root)
     # check_task_id(task_id)
     path = root.path_task(task_id)
@@ -85,6 +125,23 @@ def task_status(task_id: str, root: OptionalRoot = None) -> TaskStatus:
 
 
 def task_log(task_id: str, root: OptionalRoot = None) -> str | None:
+    """Read the task log.
+
+    Not all tasks have logs; tasks that have not yet started (status
+    of `CREATED` or `SUBMITTED` and those `CANCELLED` before starting)
+    will not have logs, and tasks that were run without capturing
+    output will not produce a log either.  Be sure to check if a
+    string was returned.
+
+    Args:
+        task_id: The task identifier to fetch the log for, a
+            32-character hex string.
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        The log as a single string, if present.
+
+    """
     root = open_root(root)
     if not task_exists(task_id, root):
         msg = f"Task '{task_id}' does not exist"
@@ -151,6 +208,23 @@ def task_info(task_id: str, root: OptionalRoot = None) -> TaskInfo:
 def task_list(
     *, root: OptionalRoot = None, with_status: TaskStatus | None = None
 ) -> list[str]:
+    """List known tasks.
+
+    Warning:
+      This function could take a long time to execute on large
+      projects with many tasks, particularly on large file systems.
+      Because the tasks are just returned as a list of strings, it may
+      not be terribly useful either.  Think before building a workflow
+      around this.
+
+    Args:
+      root: The root to search from.
+      with_status: Optional status, or set of statuses, to match
+
+    Returns:
+      A list of task identifiers.
+
+    """
     root = open_root(root)
     contents = root.path_task(None).rglob("data")
     ids = ["".join(el.parts[-3:-1]) for el in contents if el.is_file()]
@@ -184,6 +258,25 @@ def task_wait(
     allow_created: bool = False,
     **kwargs,
 ) -> bool:
+    """Wait for a task to complete.
+
+    Args:
+        task_id: The task to wait on.
+        root: The root, or if given search from the current directory.
+        allow_created: Allow waiting on a task that has status
+            `CREATED`.  Normally this is not allowed because a task
+            that is `CREATED` (and not `SUBMITTED`) will not start; if
+            you pass `allow_created=True` it is expected that you are
+            also manually evaluating this task!
+        **kwargs (Any): Additional arguments to `taskwait.taskwait`.
+
+    Returns:
+        `True` if the task completes successfully, `False` if it
+        fails.  A timeout will throw an error.  We return this boolean
+        rather than the `TaskStatus` because this generalises to
+        multiple tasks.
+
+    """
     root = open_root(root)
     task = TaskWaitWrapper(task_id, root)
 
@@ -205,6 +298,17 @@ def task_wait(
 def task_recent_rebuild(
     *, root: OptionalRoot = None, limit: int | None = None
 ) -> None:
+    """Rebuild the list of recent tasks.
+
+    Args:
+        root: The root, or if given search from the current directory.
+        limit: The maximum number of tasks to add to the recent
+            list. Use `limit=0` to truncate the list.
+
+    Returns:
+        Nothing, called for side effects only.
+
+    """
     root = open_root(root)
     path = root.path_recent()
     if limit is not None and limit == 0:
@@ -227,6 +331,19 @@ def task_recent_rebuild(
 def task_recent(
     *, root: OptionalRoot = None, limit: int | None = None
 ) -> list[str]:
+    """Return a list of recently created tasks.
+
+    Args:
+        root: The root, or if given search from the current directory.
+        limit: The maximum number of tasks to return.
+
+    Return:
+        A list of task identifiers.  The most recent tasks will be
+        **last** in this list (we might change this in a future
+        version - yes, that will be annoying).  Note that this is
+        recency in **creation**, not **completion**.
+
+    """
     root = open_root(root)
     path = root.path_recent()
     if not path.exists():
@@ -247,6 +364,17 @@ def task_recent(
 
 
 def task_last(root: OptionalRoot = None) -> str | None:
+    """Return the most recently created task.
+
+    Args:
+        root: The root, or if given search from the current directory.
+
+    Return:
+        A task identifier (a 32-character hex string) if any tasks
+        have been created (and if the recent task list has not been
+        truncated), or `None` if no tasks have been created.
+
+    """
     root = open_root(root)
     task_id = task_recent(limit=1, root=root)
     return task_id[0] if task_id else None

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -18,7 +18,7 @@ class TaskStatus(Flag):
     (this could happen from `CREATED`, `SUBMITTED` or `RUNNING`) or
     might be `MISSING` if it does not exist.
 
-    A runnable  task is  one that  we could  use `task_eval`  with; it
+    A runnable task is one that we could use `task_eval` with; it
     might be `CREATED` or `SUBMITTED`.
 
     A terminal task is one that has reached the latest state it will
@@ -94,7 +94,7 @@ def task_exists(task_id: str, root: OptionalRoot = None) -> bool:
 
     Args:
         task_id: The task identifier, a 32-character hex string.
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         `True` if the task exists.
@@ -108,7 +108,7 @@ def task_status(task_id: str, root: OptionalRoot = None) -> TaskStatus:
 
     Args:
         task_id: The task identifier to check, a 32-character hex string.
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         The status of the task.
@@ -136,7 +136,7 @@ def task_log(task_id: str, root: OptionalRoot = None) -> str | None:
     Args:
         task_id: The task identifier to fetch the log for, a
             32-character hex string.
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         The log as a single string, if present.
@@ -262,7 +262,7 @@ def task_wait(
 
     Args:
         task_id: The task to wait on.
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
         allow_created: Allow waiting on a task that has status
             `CREATED`.  Normally this is not allowed because a task
             that is `CREATED` (and not `SUBMITTED`) will not start; if
@@ -301,7 +301,7 @@ def task_recent_rebuild(
     """Rebuild the list of recent tasks.
 
     Args:
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
         limit: The maximum number of tasks to add to the recent
             list. Use `limit=0` to truncate the list.
 
@@ -334,7 +334,7 @@ def task_recent(
     """Return a list of recently created tasks.
 
     Args:
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
         limit: The maximum number of tasks to return.
 
     Return:
@@ -367,7 +367,7 @@ def task_last(root: OptionalRoot = None) -> str | None:
     """Return the most recently created task.
 
     Args:
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Return:
         A task identifier (a 32-character hex string) if any tasks

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -7,7 +7,6 @@ from hipercow.task import TaskData, TaskStatus, set_task_status
 from hipercow.util import relative_workdir
 
 
-# API here very subject to change in terms of argument order etc.
 def task_create_shell(
     cmd: list[str],
     *,
@@ -16,6 +15,37 @@ def task_create_shell(
     driver: str | None = None,
     root: OptionalRoot = None,
 ) -> str:
+    """Create a shell command task.
+
+    This is the first type of task that we support, and more types
+    will likely follow.  A shell command will evaluate an arbitrary
+    command on the cluster - it does not even need to be written in
+    Python! However, if you are using the `pip` environment engine
+    then it will need to be `pip`-installable.
+
+    The interface here is somewhat subject to change, but we think the
+    basics here are reasonable.
+
+    Args:
+        cmd: The command to execute, as a list of strings
+
+        environment: The name of the environment to evaluate the
+            command in.  The default (`None`) will select `default` if
+            available, falling back on `empty`.
+
+        envvars: A dictionary of environment variables to set before
+            the task runs.  Do not set `PATH` in here, it will not
+            currently have an effect.
+
+        driver: The driver to launch the task with.  Generally this is
+            not needed as we expect most people to have a single
+            driver set.
+
+        root: The root, or if given search from the current directory.
+
+    Returns:
+        The newly-created task identifier, a 32-character hex string.
+    """
     root = open_root(root)
     if not cmd:
         msg = "'cmd' cannot be empty"

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -41,7 +41,7 @@ def task_create_shell(
             not needed as we expect most people to have a single
             driver set.
 
-        root: The root, or if given search from the current directory.
+        root: The root, or if not given search from the current directory.
 
     Returns:
         The newly-created task identifier, a 32-character hex string.


### PR DESCRIPTION
Goodness me this is unpleasant. I have more insight now into why most package docs are so miserable to read.

I've started on reference docs here.  Most of what I expect to work out of the box does not do so and we'll need to iterate towards it:

* no autolinking.  this clearly is supported (see for example we link to `bool` in the python docs but not **within** the package when writing text). You can force this by using `[name][name]` syntax but that makes the docstrings really ugly for use with `help()`
* reuse of text! I get so used to R's `@inheritParams` but of course because there's no "build" step we can't do this.  It might possible to hack this with a generator (e.g., https://stackoverflow.com/questions/2575959/repetitive-content-in-docstrings or barely-used package https://github.com/Chilipp/docrep, see the discussion here too: https://github.com/matplotlib/matplotlib/issues/9414) but it's odd that this is hard.
* There's lots more to document and a few things that need moving into the private interface