### PR TITLE
Fetch logs from driver, including outer logs

### DIFF
--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -171,22 +171,18 @@ def cli_task_status(task_id: str):
 
 @task.command("log")
 @click.option(
-    "--filename", is_flag=True, help="Print the filename containing the log"
+    "--outer", is_flag=True, help="Print the outer logs, from the HPC system"
 )
 @click.argument("task_id")
-def cli_task_log(task_id: str, *, filename=False):
+def cli_task_log(task_id: str, *, outer=False):
     """Get a task log.
 
     If the log does not yet exist, we return nothing.
 
     """
-    if filename:
-        r = root.open_root()
-        click.echo(r.path_task_log(task_id))
-    else:
-        value = task_log(task_id)
-        if value is not None:
-            click.echo(value)
+    value = task_log(task_id, outer=outer)
+    if value is not None:
+        click.echo(value)
 
 
 @task.command("list")

--- a/src/hipercow/driver.py
+++ b/src/hipercow/driver.py
@@ -2,6 +2,7 @@ import pickle
 from abc import ABC, abstractmethod
 
 from hipercow.root import Root
+from hipercow.util import read_file_if_exists
 
 
 class HipercowDriver(ABC):
@@ -22,6 +23,13 @@ class HipercowDriver(ABC):
     @abstractmethod
     def provision(self, name: str, id: str, root: Root) -> None:
         pass  # pragma: no cover
+
+    def task_log(
+        self, task_id: str, *, outer: bool = False, root: Root
+    ) -> str | None:
+        if outer:
+            return None
+        return read_file_if_exists(root.path_task_log(task_id))
 
 
 def list_drivers(root) -> list[str]:

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -6,8 +6,9 @@ from enum import Flag, auto
 
 import taskwait
 
+from hipercow.driver import load_driver
 from hipercow.root import OptionalRoot, Root, open_root
-from hipercow.util import file_create
+from hipercow.util import file_create, read_file_if_exists
 
 
 class TaskStatus(Flag):
@@ -124,7 +125,9 @@ def task_status(task_id: str, root: OptionalRoot = None) -> TaskStatus:
     return TaskStatus.CREATED
 
 
-def task_log(task_id: str, root: OptionalRoot = None) -> str | None:
+def task_log(
+    task_id: str, *, outer: bool = False, root: OptionalRoot = None
+) -> str | None:
     """Read the task log.
 
     Not all tasks have logs; tasks that have not yet started (status
@@ -136,6 +139,8 @@ def task_log(task_id: str, root: OptionalRoot = None) -> str | None:
     Args:
         task_id: The task identifier to fetch the log for, a
             32-character hex string.
+        outer: Fetch the "outer" logs; these are logs from the
+            underlying HPC software before it hands off to hipercow.
         root: The root, or if not given search from the current directory.
 
     Returns:
@@ -146,11 +151,16 @@ def task_log(task_id: str, root: OptionalRoot = None) -> str | None:
     if not task_exists(task_id, root):
         msg = f"Task '{task_id}' does not exist"
         raise Exception(msg)
-    path = root.path_task_log(task_id)
-    if not path.exists():
-        return None
-    with path.open() as f:
-        return f.read()
+
+    driver = task_driver(task_id, root)
+    if not driver:
+        if outer:
+            msg = "outer logs are only available for tasks with drivers"
+            raise Exception(msg)
+        return read_file_if_exists(root.path_task_log(task_id))
+
+    dr = load_driver(driver, root)
+    return dr.task_log(task_id, outer=outer, root=root)
 
 
 def set_task_status(
@@ -251,7 +261,7 @@ class TaskWaitWrapper(taskwait.Task):
         return str(task_status(self.task_id, self.root))
 
     def log(self) -> list[str] | None:
-        value = task_log(self.task_id, self.root)
+        value = task_log(self.task_id, root=self.root)
         return value.splitlines() if value else None
 
     def has_log(self):

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -88,4 +88,4 @@ def _new_task_id() -> str:
 def _submit_maybe(task_id: str, driver: str | None, root: Root) -> None:
     if dr := load_driver_optional(driver, root):
         dr.submit(task_id, root)
-        set_task_status(task_id, TaskStatus.SUBMITTED, driver, root)
+        set_task_status(task_id, TaskStatus.SUBMITTED, dr.name, root)

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -88,4 +88,4 @@ def _new_task_id() -> str:
 def _submit_maybe(task_id: str, driver: str | None, root: Root) -> None:
     if dr := load_driver_optional(driver, root):
         dr.submit(task_id, root)
-        set_task_status(task_id, TaskStatus.SUBMITTED, root)
+        set_task_status(task_id, TaskStatus.SUBMITTED, driver, root)

--- a/src/hipercow/task_eval.py
+++ b/src/hipercow/task_eval.py
@@ -38,7 +38,7 @@ def task_eval_data(data: TaskData, *, capture: bool, root: Root) -> None:
     t_created = root.path_task_data(task_id).stat().st_ctime
     t_start = time.time()
 
-    set_task_status(task_id, TaskStatus.RUNNING, root)
+    set_task_status(task_id, TaskStatus.RUNNING, None, root)
 
     assert data.method == "shell"  # noqa: S101
     res = task_eval_shell(data, capture=capture, root=root)
@@ -52,7 +52,7 @@ def task_eval_data(data: TaskData, *, capture: bool, root: Root) -> None:
     times = TaskTimes(t_created, t_start, t_end)
     times.write(task_id, root)
 
-    set_task_status(task_id, status, root)
+    set_task_status(task_id, status, None, root)
 
 
 def task_eval_shell(data: TaskData, *, capture: bool, root: Root) -> TaskResult:

--- a/src/hipercow/util.py
+++ b/src/hipercow/util.py
@@ -112,3 +112,10 @@ def check_python_version(
 def truthy_envvar(name: str) -> bool:
     value = os.environ.get(name)
     return value is not None and (value.lower() in {"1", "true"})
+
+
+def read_file_if_exists(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    with path.open() as f:
+        return f.read()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,9 +75,9 @@ def test_can_save_and_read_log(tmp_path):
         assert res.exit_code == 0
         assert res.output == "hello world\n\n"
 
-        res = runner.invoke(cli.cli_task_log, [task_id, "--filename"])
-        assert res.exit_code == 0
-        assert res.output.strip() == str(r.path_task_log(task_id))
+        res = runner.invoke(cli.cli_task_log, [task_id, "--outer"])
+        assert res.exit_code == 1
+        assert "outer logs are only available" in str(res.exception)
 
 
 def test_can_process_with_status_args():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,6 @@ def test_can_save_and_read_log(tmp_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
         root.init(".")
-        r = root.open_root()
         res = runner.invoke(cli.cli_task_create, ["echo", "hello", "world"])
         task_id = res.stdout.strip()
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -62,7 +62,7 @@ def test_that_missing_tasks_error_on_log_read(tmp_path):
     r = root.open_root(tmp_path)
     task_id = "a" * 32
     with pytest.raises(Exception, match="Task '.+' does not exist"):
-        task_log(task_id, r)
+        task_log(task_id, root=r)
 
 
 def test_can_convert_to_nice_string():
@@ -259,3 +259,12 @@ def test_can_read_driver_for_submitted_task(tmp_path):
     assert task_driver(tid, r) == "example"
     set_task_status(tid, TaskStatus.SUCCESS, None, r)
     assert task_driver(tid, r) == "example"
+
+
+def test_no_outer_log_without_submission(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    with transient_working_directory(tmp_path):
+        tid = tc.task_create_shell(["echo", "hello world"], root=r)
+    with pytest.raises(Exception, match="outer logs are only available"):
+        task_log(tid, outer=True, root=r)

--- a/tests/test_task_eval.py
+++ b/tests/test_task_eval.py
@@ -39,7 +39,7 @@ def test_can_capture_output_to_auto_file(tmp_path):
     with path.open("r") as f:
         assert f.read().strip() == "hello world"
 
-    assert task_log(tid, r) == "hello world\n"
+    assert task_log(tid, root=r) == "hello world\n"
 
 
 def test_return_information_about_failure_to_find_path(tmp_path):

--- a/tests/zzz/test_environment.py
+++ b/tests/zzz/test_environment.py
@@ -26,4 +26,4 @@ def test_run_in_environment(tmp_path):
         task_eval(tid, capture=True, root=r)
 
         assert task_status(tid, r) == TaskStatus.SUCCESS
-        assert "| hello |" in task_log(tid, r)
+        assert "| hello |" in task_log(tid, root=r)


### PR DESCRIPTION
Bit of a rapid-fire refactor here.  The driver should be the thing that fetches the logs, we should not just read off disk.  This is to support the idea that a task might run elsewhere, and it's also required to support getting the outer logs.

We also need to store the dide id somewhere, and the driver used for submission!