### PR TITLE
Validate resources in driver, use in submission

### DIFF
--- a/src/hipercow/dide/bootstrap.py
+++ b/src/hipercow/dide/bootstrap.py
@@ -8,6 +8,7 @@ from taskwait import Task, taskwait
 from hipercow.dide.driver import _web_client
 from hipercow.dide.mounts import Mount, _backward_slash, detect_mounts
 from hipercow.dide.web import DideWebClient
+from hipercow.resources import TaskResources
 
 BOOTSTRAP = Template(
     r"""call set_python_${version2}_64
@@ -78,7 +79,8 @@ def _bootstrap_submit(
     with path_local.open("w") as f:
         f.write(_batch_bootstrap(version, target, args))
 
-    dide_id = client.submit(_bootstrap_unc(path), name)
+    resources = TaskResources(queue="BuildQueue")
+    dide_id = client.submit(_bootstrap_unc(path), name, resources)
     return BootstrapTask(client, dide_id, version)
 
 

--- a/src/hipercow/dide/driver.py
+++ b/src/hipercow/dide/driver.py
@@ -8,7 +8,7 @@ from hipercow.dide.configuration import DideConfiguration
 from hipercow.dide.mounts import detect_mounts
 from hipercow.dide.web import DideWebClient
 from hipercow.driver import HipercowDriver
-from hipercow.resources import ClusterResources, Queues
+from hipercow.resources import ClusterResources, Queues, TaskResources
 from hipercow.root import Root
 
 
@@ -27,10 +27,12 @@ class DideWindowsDriver(HipercowDriver):
         print(f"  share: \\\\{path_map.mount.host}\\{path_map.mount.remote}")
         print(f"python version: {self.config.python_version}")
 
-    def submit(self, task_id: str, root: Root) -> None:
+    def submit(
+        self, task_id: str, resources: TaskResources | None, root: Root
+    ) -> None:
         cl = _web_client()
         unc = write_batch_task_run(task_id, self.config, root)
-        dide_id = cl.submit(unc, task_id)
+        dide_id = cl.submit(unc, task_id, resources=resources)
         with self._path_dide_id(task_id, root).open("w") as f:
             f.write(dide_id)
 

--- a/src/hipercow/dide/driver.py
+++ b/src/hipercow/dide/driver.py
@@ -8,6 +8,7 @@ from hipercow.dide.configuration import DideConfiguration
 from hipercow.dide.mounts import detect_mounts
 from hipercow.dide.web import DideWebClient
 from hipercow.driver import HipercowDriver
+from hipercow.resources import ClusterResources, Queues
 from hipercow.root import Root
 
 
@@ -35,6 +36,19 @@ class DideWindowsDriver(HipercowDriver):
 
     def provision(self, name: str, id: str, root: Root) -> None:
         _dide_provision(name, id, self.config, root)
+
+    def resources(self) -> ClusterResources:
+        # We should get this from the cluster itself but with caching
+        # not yet configured this seems unwise as we'll hit the
+        # cluster an additional time for every job submission rather
+        # than just once a session.
+        queues = Queues(
+            {"AllNodes", "BuildQueue", "Testing"},
+            default="AllNodes",
+            test="Testing",
+            build="BuildQueue",
+        )
+        return ClusterResources(queues=queues, max_cores=32, max_memory=512)
 
     def task_log(
         self, task_id: str, *, outer: bool = False, root: Root

--- a/src/hipercow/dide/driver.py
+++ b/src/hipercow/dide/driver.py
@@ -32,6 +32,8 @@ class DideWindowsDriver(HipercowDriver):
     ) -> None:
         cl = _web_client()
         unc = write_batch_task_run(task_id, self.config, root)
+        if not resources:
+            resources = self.resources().validate_resources(TaskResources())
         dide_id = cl.submit(unc, task_id, resources=resources)
         with self._path_dide_id(task_id, root).open("w") as f:
             f.write(dide_id)
@@ -107,7 +109,7 @@ def _web_client() -> DideWebClient:
 def _dide_provision(name: str, id: str, config: DideConfiguration, root: Root):
     cl = _web_client()
     unc = write_batch_provision(name, id, config, root)
-    template = "BuildQueue"
-    dide_id = cl.submit(unc, f"{name}/{id}", template=template)
+    resources = TaskResources(queue="BuildQueue")
+    dide_id = cl.submit(unc, f"{name}/{id}", resources=resources)
     task = ProvisionWaitWrapper(root, name, id, cl, dide_id)
     taskwait(task)

--- a/src/hipercow/dide/web.py
+++ b/src/hipercow/dide/web.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin
 import requests
 from defusedxml import ElementTree
 
+from hipercow.resources import TaskResources
 from hipercow.task import TaskStatus
 
 
@@ -121,6 +122,7 @@ class DideWebClient:
         path: str,
         name: str,
         *,
+        resources: TaskResources | None = None,
         template: str | None = None,
         workdir: str | None = None,
     ) -> str:

--- a/src/hipercow/driver.py
+++ b/src/hipercow/driver.py
@@ -1,7 +1,7 @@
 import pickle
 from abc import ABC, abstractmethod
 
-from hipercow.resources import ClusterResources
+from hipercow.resources import ClusterResources, TaskResources
 from hipercow.root import Root
 from hipercow.util import read_file_if_exists
 
@@ -18,7 +18,9 @@ class HipercowDriver(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def submit(self, task_id: str, root: Root) -> None:
+    def submit(
+        self, task_id: str, resources: TaskResources | None, root: Root
+    ) -> None:
         pass  # pragma: no cover
 
     @abstractmethod

--- a/src/hipercow/driver.py
+++ b/src/hipercow/driver.py
@@ -1,6 +1,7 @@
 import pickle
 from abc import ABC, abstractmethod
 
+from hipercow.resources import ClusterResources
 from hipercow.root import Root
 from hipercow.util import read_file_if_exists
 
@@ -22,6 +23,10 @@ class HipercowDriver(ABC):
 
     @abstractmethod
     def provision(self, name: str, id: str, root: Root) -> None:
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def resources(self) -> ClusterResources:
         pass  # pragma: no cover
 
     def task_log(

--- a/src/hipercow/example.py
+++ b/src/hipercow/example.py
@@ -1,5 +1,6 @@
 from hipercow.driver import HipercowDriver
 from hipercow.provision import provision_run
+from hipercow.resources import ClusterResources, Queues
 from hipercow.root import Root
 from hipercow.util import check_python_version
 
@@ -27,3 +28,10 @@ class ExampleDriver(HipercowDriver):
 
     def provision(self, name: str, id: str, root: Root) -> None:
         provision_run(name, id, root)
+
+    def resources(self) -> ClusterResources:
+        return ClusterResources(
+            queues=Queues.simple("default"),
+            max_cores=1,
+            max_memory=32,
+        )

--- a/src/hipercow/example.py
+++ b/src/hipercow/example.py
@@ -1,6 +1,6 @@
 from hipercow.driver import HipercowDriver
 from hipercow.provision import provision_run
-from hipercow.resources import ClusterResources, Queues
+from hipercow.resources import ClusterResources, Queues, TaskResources
 from hipercow.root import Root
 from hipercow.util import check_python_version
 
@@ -23,7 +23,12 @@ class ExampleDriver(HipercowDriver):
     def show_configuration(self) -> None:
         print("(no configuration)")
 
-    def submit(self, task_id, root: Root) -> None:  # noqa: ARG002
+    def submit(
+        self,
+        task_id: str,
+        resources: TaskResources | None,  # noqa: ARG002
+        root: Root,  # noqa: ARG002
+    ) -> None:
         print(f"submitting '{task_id}'")
 
     def provision(self, name: str, id: str, root: Root) -> None:

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -7,6 +7,7 @@ from enum import Flag, auto
 import taskwait
 
 from hipercow.driver import load_driver
+from hipercow.resources import TaskResources
 from hipercow.root import OptionalRoot, Root, open_root
 from hipercow.util import file_create, read_file_if_exists
 
@@ -174,13 +175,14 @@ def set_task_status(
             f.write(value)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TaskData:
     task_id: str
     method: str  # shell etc
     data: dict
     path: str
     environment: str
+    resources: TaskResources | None
     envvars: dict[str, str]
 
     def write(self, root: Root):

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -84,7 +84,7 @@ def _task_create(
     if resources:
         if not dr:
             msg = "Can't specify resources, as driver is not given"
-            raise ValueError(msg)
+            raise Exception(msg)
         dr.resources().validate_resources(resources)
     task_data = TaskData(
         task_id=task_id,

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -85,7 +85,7 @@ def _task_create(
         if not dr:
             msg = "Can't specify resources, as driver is not given"
             raise Exception(msg)
-        dr.resources().validate_resources(resources)
+        resources = dr.resources().validate_resources(resources)
     task_data = TaskData(
         task_id=task_id,
         method=method,
@@ -99,7 +99,7 @@ def _task_create(
     with root.path_recent().open("a") as f:
         f.write(f"{task_id}\n")
     if dr:
-        dr.submit(task_id, root)
+        dr.submit(task_id, resources, root)
         set_task_status(task_id, TaskStatus.SUBMITTED, dr.name, root)
     return task_id
 

--- a/tests/dide/test_bootstrap.py
+++ b/tests/dide/test_bootstrap.py
@@ -15,6 +15,7 @@ from hipercow.dide.bootstrap import (
 )
 from hipercow.dide.mounts import Mount
 from hipercow.dide.web import DideWebClient
+from hipercow.resources import TaskResources
 
 
 def test_can_construct_unc_paths():
@@ -66,12 +67,13 @@ def test_can_submit_bootstrap_task(tmp_path):
     target = "hipercow"
     args = ""
     t = _bootstrap_submit(client, mount, bootstrap_id, version, target, args)
-
+    resources = TaskResources(queue="BuildQueue")
     assert t.client == client
     assert client.submit.call_count == 1
     assert client.submit.mock_calls[0] == mock.call(
         r"\\wpia-hn\hipercow\bootstrap-py-windows\in\abcdef\3.11.bat",
         "bootstrap/abcdef/3.11",
+        resources,
     )
     assert t.dide_id == client.submit.return_value
     dest = tmp_path / "bootstrap-py-windows/in/abcdef/3.11.bat"

--- a/tests/dide/test_configure.py
+++ b/tests/dide/test_configure.py
@@ -75,6 +75,22 @@ def test_provision_using_driver(tmp_path, mocker):
     )
 
 
+def test_resources_using_driver(tmp_path, mocker):
+    path = tmp_path / "a" / "b"
+    root.init(path)
+    r = root.open_root(path)
+    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mock_provision = mock.MagicMock()
+    mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
+    mocker.patch("hipercow.dide.driver._dide_provision", mock_provision)
+    configure("dide-windows", python_version=None, root=r)
+    dr = load_driver(None, r)
+    resources = dr.resources()
+    assert resources.queues.default == "AllNodes"
+    assert resources.max_cores == 32
+    assert resources.max_memory == 512
+
+
 def test_configure_python_version(tmp_path, mocker, capsys):
     path = tmp_path / "a" / "b"
     root.init(path)

--- a/tests/dide/test_provision.py
+++ b/tests/dide/test_provision.py
@@ -7,6 +7,7 @@ from hipercow.dide import mounts
 from hipercow.dide.configuration import DideConfiguration
 from hipercow.dide.driver import ProvisionWaitWrapper, _dide_provision
 from hipercow.dide.web import DideWebClient
+from hipercow.resources import TaskResources
 from hipercow.task import TaskStatus
 from hipercow.util import transient_working_directory
 
@@ -29,12 +30,13 @@ def test_can_provision_with_dide(tmp_path, mocker):
     config = DideConfiguration(r, mounts=[m], python_version=None)
 
     _dide_provision("myenv", "abcdef", config, r)
+    resources = TaskResources(queue="BuildQueue")
 
     assert mock_client.submit.call_count == 1
     assert mock_client.mock_calls[0] == mock.call.submit(
         r"\\host\hostmount\path\to\dir\hipercow\py\env\myenv\provision\abcdef\run.bat",
         "myenv/abcdef",
-        template="BuildQueue",
+        resources=resources,
     )
 
     assert hipercow.dide.driver.taskwait.call_count == 1

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -112,3 +112,11 @@ def test_can_read_logs_with_example_driver(tmp_path):
     assert dr.task_log(tid, outer=True, root=r) is None
     assert task_log(tid, root=r) == "hello world\n"
     assert task_log(tid, outer=True, root=r) is None
+
+
+def test_that_example_driver_has_reasonable_resources(tmp_path):
+    dr = ExampleDriver(root.init(tmp_path))
+    resources = dr.resources()
+    assert resources.queues.valid == {"default"}
+    assert resources.max_cores == 1
+    assert resources.max_memory == 32

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -5,6 +5,7 @@ import pytest
 from hipercow import root
 from hipercow import task_create as tc
 from hipercow.configure import configure
+from hipercow.resources import TaskResources
 from hipercow.task import TaskData, TaskStatus, task_status
 from hipercow.util import transient_working_directory
 
@@ -26,6 +27,7 @@ def test_create_simple_task(tmp_path):
     assert d.data == {"cmd": ["echo", "hello world"]}
     assert d.path == "."
     assert d.envvars == {}
+    assert d.resources is None
 
 
 def test_tasks_cannot_be_empty(tmp_path):
@@ -46,3 +48,41 @@ def test_submit_with_driver_if_configured(tmp_path, capsys):
     str1 = capsys.readouterr().out
     assert str1.startswith(f"submitting '{tid}'")
     assert task_status(tid, r) == TaskStatus.SUBMITTED
+
+
+def test_resources_require_configured_driver(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    resources = TaskResources(queue="foo")
+    with transient_working_directory(tmp_path):
+        with pytest.raises(Exception, match="Can't specify resources"):
+            tc.task_create_shell(
+                ["echo", "hello world"], resources=resources, root=r
+            )
+
+
+def test_resources_validated_on_submission(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    configure("example", root=r)
+    resources = TaskResources(queue="foo")
+    with transient_working_directory(tmp_path):
+        with pytest.raises(
+            Exception, match="Queue 'foo' is not in valid queue list"
+        ):
+            tc.task_create_shell(
+                ["echo", "hello world"], resources=resources, root=r
+            )
+
+
+def test_can_save_resources_on_submission(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    configure("example", root=r)
+    resources = TaskResources(memory_per_task=1)
+    with transient_working_directory(tmp_path):
+        tid = tc.task_create_shell(
+            ["echo", "hello world"], resources=resources, root=r
+        )
+    d = TaskData.read(tid, root.open_root(tmp_path))
+    assert d.resources == TaskResources(queue="default", memory_per_task=1)


### PR DESCRIPTION
Most of the way to usable resources here, this PR builds on #53, and passes the resources around during task creation and through to the web driver.  It's not yet exposed in the cli