### PR TITLE
Print information on failed provisioning

### DIFF
--- a/src/hipercow/cli.py
+++ b/src/hipercow/cli.py
@@ -145,13 +145,12 @@ def cli_driver_configure(name: str, python_version: str | None):
 
     This command will initialise a driver.  Most likely you will call
 
-    ```
-    hipercow driver configure dide
-    ```
+        hipercow driver configure dide-windows
 
-    because `dide` is the only real driver at the moment.  In future
-    there will be options that you might pass here, or some other way
-    to control its behaviour.
+    because `dide-windows` is the only real driver at the moment.  If
+    you provide the `--python-version` flag you can specify the Python
+    version to use, if you want a version that is different to the
+    version of Python that you are using locally.
 
     """
     configure(name, python_version=python_version)

--- a/src/hipercow/dide/driver.py
+++ b/src/hipercow/dide/driver.py
@@ -112,4 +112,22 @@ def _dide_provision(name: str, id: str, config: DideConfiguration, root: Root):
     resources = TaskResources(queue="BuildQueue")
     dide_id = cl.submit(unc, f"{name}/{id}", resources=resources)
     task = ProvisionWaitWrapper(root, name, id, cl, dide_id)
-    taskwait(task)
+    res = taskwait(task)
+    dt = round(res.end - res.start, 2)
+    if res.status == "failure":
+        path_log = root.path_provision_log(name, id, relative=True)
+        print(f"Provisioning failed after {dt}s!")
+        print("")
+        print("Logs, if produced, may be visible above")
+        print("A copy of all logs is available at:")
+        print(f"    {path_log}")
+        print("")
+        print("Additionally, logs available from the cluster follow:")
+        print("-" * 70)
+        dide_log = cl.log(dide_id)
+        print(dide_log)
+        print("-" * 70)
+        msg = "Provisioning failed"
+        raise Exception(msg)
+    else:
+        print(f"Provisioning completed in {dt}s")

--- a/src/hipercow/environment_engines/base.py
+++ b/src/hipercow/environment_engines/base.py
@@ -37,7 +37,11 @@ class EnvironmentEngine(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def provision(self, cmd: list[str] | None, **kwargs) -> None:
+    def check_args(self, cmd: list[str] | None) -> list[str]:
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def provision(self, cmd: list[str], **kwargs) -> None:
         pass  # pragma: no cover
 
     @abstractmethod

--- a/src/hipercow/environment_engines/empty.py
+++ b/src/hipercow/environment_engines/empty.py
@@ -22,9 +22,14 @@ class Empty(EnvironmentEngine):
         msg = "Can't create the empty environment!"
         raise Exception(msg)
 
-    def provision(
-        self, cmd: list[str] | None, **kwargs  # noqa: ARG002
-    ) -> None:
+    def check_args(self, cmd: list[str] | None) -> list[str]:
+        if not cmd:
+            return []
+        else:
+            msg = "No arguments are allowed to the empty environment"
+            raise Exception(msg)
+
+    def provision(self, cmd: list[str], **kwargs) -> None:  # noqa: ARG002
         msg = "Can't provision the empty environment!"
         raise Exception(msg)
 

--- a/src/hipercow/environment_engines/pip.py
+++ b/src/hipercow/environment_engines/pip.py
@@ -24,8 +24,16 @@ class Pip(EnvironmentEngine):
         cmd = ["python", "-m", "venv", str(self.path())]
         subprocess_run(cmd, check=True, **kwargs)
 
-    def provision(self, cmd: list[str] | None, **kwargs) -> None:
-        self.run(self._check_args(cmd), check=True, **kwargs)
+    def check_args(self, cmd: list[str] | None) -> list[str]:
+        if not cmd:
+            return self._auto()
+        if cmd[0] != "pip":
+            msg = "Expected first element of 'cmd' to be 'pip'"
+            raise Exception(msg)
+        return cmd
+
+    def provision(self, cmd: list[str], **kwargs) -> None:
+        self.run(cmd, check=True, **kwargs)
 
     def run(
         self,
@@ -70,14 +78,6 @@ class Pip(EnvironmentEngine):
             return ["pip", "install", "--verbose", "-r", "requirements.txt"]
         msg = "Can't determine install command"
         raise Exception(msg)
-
-    def _check_args(self, cmd: list[str] | None) -> list[str]:
-        if not cmd:
-            return self._auto()
-        if cmd[0] != "pip":
-            msg = "Expected first element of 'cmd' to be 'pip'"
-            raise Exception(msg)
-        return cmd
 
     def _venv_bin_dir(self) -> str:
         return "Scripts" if self.platform.system == "windows" else "bin"

--- a/tests/dide/test_configure.py
+++ b/tests/dide/test_configure.py
@@ -11,7 +11,7 @@ from hipercow.provision import provision
 from hipercow.resources import TaskResources
 from hipercow.task import task_log
 from hipercow.task_create import task_create_shell
-from hipercow.util import transient_working_directory
+from hipercow.util import file_create, transient_working_directory
 
 
 def test_can_configure_dide_mount(tmp_path, mocker):
@@ -101,6 +101,7 @@ def test_provision_using_driver(tmp_path, mocker):
     mocker.patch("hipercow.dide.driver._dide_provision", mock_provision)
     configure("dide-windows", python_version=None, root=r)
     environment_new("default", "pip", r)
+    file_create(r.path / "requirements.txt")
     provision("default", [], root=r)
     cfg = load_driver(None, r).config
     assert mock_provision.call_count == 1

--- a/tests/test_environment_empty.py
+++ b/tests/test_environment_empty.py
@@ -52,3 +52,13 @@ def test_can_run_command_in_empty_env(tmp_path, mocker):
     assert mock_run.mock_calls[0] == mock.call(
         ["some", "command"], env=os.environ, check=False
     )
+
+
+def test_can_validate_empty_args(tmp_path):
+    root.init(tmp_path)
+    r = root.open_root(tmp_path)
+    env = environment_engine("empty", r)
+    assert env.check_args(None) == []
+    assert env.check_args([]) == []
+    with pytest.raises(Exception, match="No arguments are allowed"):
+        env.check_args(["other"])

--- a/tests/test_environment_pip.py
+++ b/tests/test_environment_pip.py
@@ -39,10 +39,12 @@ def test_pip_environment_can_be_created(tmp_path, mocker):
     )
 
     with transient_working_directory(tmp_path):
-        env.provision(None)
+        cmd = env.check_args(None)
+        assert cmd == ["pip", "install", "--verbose", "-r", "requirements.txt"]
+        env.provision(cmd)
         assert mock_run.call_count == 2
         assert mock_run.mock_calls[1] == mock.call(
-            ["pip", "install", "--verbose", "-r", "requirements.txt"],
+            cmd,
             env=os.environ | envvars,
             check=True,
         )
@@ -68,12 +70,12 @@ def test_pip_can_determine_sensible_default_cmd(tmp_path):
         file_create(tmp_path / "pyproject.toml")
         assert env._auto() == ["pip", "install", "--verbose", "."]
 
-        assert env._check_args(None) == ["pip", "install", "--verbose", "."]
-        assert env._check_args([]) == ["pip", "install", "--verbose", "."]
-        assert env._check_args(["pip", "install", "x"]) == [
+        assert env.check_args(None) == ["pip", "install", "--verbose", "."]
+        assert env.check_args([]) == ["pip", "install", "--verbose", "."]
+        assert env.check_args(["pip", "install", "x"]) == [
             "pip",
             "install",
             "x",
         ]
         with pytest.raises(Exception, match="Expected first element"):
-            assert env._check_args(["pwd"])
+            assert env.check_args(["pwd"])


### PR DESCRIPTION
Not too bad in the end. Tested by breaking the batch file and getting some nice print outs in return

```
(hipercow) rfitzjoh@wpia-dide300:~/net/home/cluster/testing$ hipercow environment provision
WaitingOK
Provisioning failed after 0.72s!

Logs, if produced, may be visible above
A copy of all logs is available at:
    hipercow/py/env/default/provision/9d67cd36484ac6a5/log

Additionally, logs available from the cluster follow:
----------------------------------------------------------------------
Task failed during execution with exit code . Please check task's output for error details.
Output                          :
generated on host: wpia-dide300
generated on date: 2025-03-12 15:21:28.219412+00:00
hipercow(py) version: 0.1.1
running on: WPIA-HN
The command completed successfully.

working directory: Q:\cluster\testing
this is a provisioning task
The system cannot find the drive specified.
ERRORLEVEL was 0
Cleaning up
Q: was deleted successfully.

The network connection could not be found.

More help is available by typing NET HELPMSG 2250.

Quitting


----------------------------------------------------------------------
Error: Provisioning failed
For more information, run with 'HIPERCOW_TRACEBACK=1'
```

Also, and after some refactoring, catches the error that the `pip` environment throws when determining the appropriate installation command