### PR TITLE
Support for creating a bundle of tasks from a templated command

### DIFF
--- a/src/hipercow/task_create_bulk.py
+++ b/src/hipercow/task_create_bulk.py
@@ -13,9 +13,9 @@ class _TemplateAt(Template):
     # Backport a simplified version of get_idenfiers for python 3.10,
     # which lacks this method https://docs.python.org/3/library/string.html
     # no cover: start
-    if not hasattr(Template, "foo"):
+    if not hasattr(Template, "get_identifiers"):
 
-        def get_identnfiers(self):
+        def get_identifiers(self):
             return _template_identifiers(self)
 
     # no cover: end

--- a/src/hipercow/task_create_bulk.py
+++ b/src/hipercow/task_create_bulk.py
@@ -128,7 +128,7 @@ def _check_template_data(data: BulkDataInput) -> list[dict[str, str]]:
         keys = data[0].keys()
         for el in data[1:]:
             if el.keys() != keys:
-                msg = "Unexpected keys"
+                msg = "Inconsistent keys among data"
                 raise Exception(msg)
         return data
     else:

--- a/src/hipercow/task_create_bulk.py
+++ b/src/hipercow/task_create_bulk.py
@@ -1,0 +1,143 @@
+import csv
+from pathlib import Path
+from string import Template
+
+from hipercow.bundle import bundle_create
+from hipercow.root import OptionalRoot, open_root
+from hipercow.task_create import task_create_shell
+from hipercow.util import expand_grid
+
+
+class _TemplateAt(Template):
+    delimiter = "@"
+
+
+# ignoring the details of doing the substitutions, this is really all
+# we need to do:
+def bulk_create_shell(
+    cmd_template: list[str],
+    data: list[dict[str, str]],
+    *,
+    name: str | None = None,
+    root: OptionalRoot = None,
+    **kwargs,
+) -> str:
+    """Create a group of tasks from a template and data.
+
+    You may want to use `bulk_crete_shell_commands` to preview the set
+    of commands that would be created.
+
+    There are a couple of ways that you might want to load data into
+    the template:
+
+    * You might have data in a table (e.g., in csv file).  In this
+      case we might model this as a list of `dict`s, each
+      corresponding to a row in the original table.
+
+    * You might have a series of factors that you want to compute all
+      possible combinations of.  In this case we might model this as a
+      dictionary of lists.
+
+    We will handle either type and try and do the right thing.  This
+    necessitates a bit of magic, and we may tone this down in future
+    if it ends up being too unpredictable.
+
+    Args:
+        cmd_template: A command template.  This should be a list of
+            strings, with some containing template placeholders.
+
+        data: A list of dictionaries to substitute into the template.
+
+        name: Optional name for the created bundle.  If `None` (the
+            default) then a random name will be creted for the bundle.
+
+        root: The root, or if not given search from the current directory.
+
+        kwargs: Additional arguments passed through to
+            `hipercow.task_create.task_create_shell`.  This includes
+            `environment`, `envvars`, `resources` and `driver`.
+
+    Returns: The name of the created bundle of tasks.  You can use
+        `hipercow.bundle.task_bundle_load` to load this and methods in
+        `hipercow.bundle` to interact with or query the bundle.
+
+    """
+    root = open_root(root)
+    cmd = bulk_create_shell_commands(cmd_template, data)
+    task_ids = [task_create_shell(cmd_i, **kwargs) for cmd_i in cmd]
+    return bundle_create(task_ids, name=name, validate=False, root=root)
+
+
+def bulk_create_shell_commands(
+    cmd_template: list[str], data: list[dict[str, str]]
+) -> list[list[str]]:
+    """Create a list of commands from a template and data.
+
+    Creates the list of commands (each of which is a list of strings)
+    by using a **command template** -- a list of strings containing
+    `@{...}` placeholders -- and data to substitute into this.
+
+    You can use this to debug or preview commands that would be
+    produced by `bust_create_shell` without accidentally submitting
+    thousands of tasks.
+
+    Args:
+        cmd_template: A command template.  This should be a list of
+            strings, with some containing template placeholders.
+
+        data: A list of dictionaries to substitute into the template.
+
+    Returns: A list of lists of strings; the `i`th element of this is
+    the command substituted from the `i`th element of `data`.
+
+    """
+    template = [_TemplateAt(el) for el in cmd_template]
+
+    # Check that all elements in data are consumed by the template
+
+    keys_template = set()
+    for el in template:
+        keys_template |= set(el.get_identifiers())
+
+    keys_data = _check_template_data(data)
+
+    if keys_template != set(keys_data):
+        # Make this one better; we need to provide information about
+        # the unexpected or missing elements really.  Perhaps it's
+        # fine if there is data provided that is not interpolated
+        # though?  Maybe that's an option?  Definitely elements found
+        # in the
+        msg = "Unexpected substitutions found in template"
+        raise Exception(msg)
+
+    return [[i.substitute(d) for i in template] for d in data]
+
+
+def _check_template_data(data: list[dict[str, str]]) -> list[str]:
+    if not data:
+        msg = "No data provided"
+        raise Exception(msg)
+
+    # There is no real need to do this if we have created things by
+    # reading a csv or by expanding, which is most of the way that we
+    # get here...
+    keys = data[0].keys()
+    for el in data[1:]:
+        if el.keys() != keys:
+            msg = "Unexpected keys"
+            raise Exception(msg)
+
+    return list(keys)
+
+
+def _bulk_data_csv(filename: str | Path) -> list[dict[str, str]]:
+    with Path(filename).open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _bulk_data_combine(
+    data: dict[str, str | list[str]],
+) -> list[dict[str, str]]:
+    return expand_grid(
+        {k: v if isinstance(v, list) else [v] for k, v in data.items()}
+    )

--- a/src/hipercow/task_create_bulk.py
+++ b/src/hipercow/task_create_bulk.py
@@ -10,6 +10,25 @@ from hipercow.util import expand_grid
 class _TemplateAt(Template):
     delimiter = "@"
 
+    # Backport a simplified version of get_idenfiers for python 3.10,
+    # which lacks this method https://docs.python.org/3/library/string.html
+    # no cover: start
+    if not hasattr(Template, "foo"):
+
+        def get_identnfiers(self):
+            return _template_identifiers(self)
+
+    # no cover: end
+
+
+def _template_identifiers(obj: Template) -> list[str]:
+    ids = []
+    for mo in obj.pattern.finditer(obj.template):
+        named = mo.group("named") or mo.group("braced")
+        if named is not None and named not in ids:
+            ids.append(named)
+    return ids
+
 
 BulkDataInput: TypeAlias = list[dict[str, str]] | dict[str, str | list[str]]
 

--- a/src/hipercow/task_create_bulk.py
+++ b/src/hipercow/task_create_bulk.py
@@ -51,7 +51,7 @@ def bulk_create_shell(
     There are a couple of ways that you might want to load data into
     the template:
 
-    * You might have data in a table (e.g., in csv file).  In this
+    * You might have data in a table (e.g., in a csv file).  In this
       case we might model this as a list of `dict`s, each
       corresponding to a row in the original table.
 
@@ -70,7 +70,7 @@ def bulk_create_shell(
         data: A list of dictionaries to substitute into the template.
 
         name: Optional name for the created bundle.  If `None` (the
-            default) then a random name will be creted for the bundle.
+            default) then a random name will be created for the bundle.
 
         root: The root, or if not given search from the current directory.
 
@@ -99,7 +99,7 @@ def bulk_create_shell_commands(
     `@{...}` placeholders -- and data to substitute into this.
 
     You can use this to debug or preview commands that would be
-    produced by `bust_create_shell` without accidentally submitting
+    produced by `bulk_create_shell` without accidentally submitting
     thousands of tasks.
 
     Args:

--- a/src/hipercow/task_create_bulk.py
+++ b/src/hipercow/task_create_bulk.py
@@ -104,14 +104,16 @@ def bulk_create_shell_commands(
         keys_template |= set(el.get_identifiers())
 
     data_list = _check_template_data(data)
+    keys_data = set(data_list[0].keys())
 
-    if keys_template != set(data_list[0].keys()):
-        # Make this one better; we need to provide information about
-        # the unexpected or missing elements really.  Perhaps it's
-        # fine if there is data provided that is not interpolated
-        # though?  Maybe that's an option?  Definitely elements found
-        # in the
-        msg = "Unexpected substitutions found in template"
+    if extra := keys_template - keys_data:
+        extra_str = ", ".join(extra)
+        msg = f"Template variables not present in data: {extra_str}"
+        raise Exception(msg)
+
+    if unused := keys_data - keys_template:
+        unused_str = ", ".join(unused)
+        msg = f"Data variables not present in template: {unused_str}"
         raise Exception(msg)
 
     return [[i.substitute(d) for i in template] for d in data_list]

--- a/src/hipercow/util.py
+++ b/src/hipercow/util.py
@@ -152,9 +152,3 @@ def expand_grid(data: dict) -> list[dict]:
         dict(zip(data.keys(), el, strict=False))
         for el in product(*data.values())
     ]
-
-
-# Probably some more work here to get the name to str here?
-def read_csv_to_dict(filename: str | Path) -> list[dict[str, Any]]:
-    with Path(filename).open(newline="") as f:
-        return list(csv.DictReader(f))

--- a/src/hipercow/util.py
+++ b/src/hipercow/util.py
@@ -1,4 +1,3 @@
-import csv
 import os
 import platform
 import re
@@ -8,7 +7,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
-from typing import Any
 
 
 def find_file_descend(filename: str, path: str | Path) -> Path | None:

--- a/src/hipercow/util.py
+++ b/src/hipercow/util.py
@@ -5,6 +5,7 @@ import subprocess
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from itertools import product
 from pathlib import Path
 
 
@@ -142,3 +143,10 @@ class Result:
     @staticmethod
     def err(exception: Exception) -> "Result":
         return Result(exception)
+
+
+def expand_grid(data: dict) -> list[dict]:
+    return [
+        dict(zip(data.keys(), el, strict=False))
+        for el in product(*data.values())
+    ]

--- a/src/hipercow/util.py
+++ b/src/hipercow/util.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import platform
 import re
@@ -7,6 +8,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
+from typing import Any
 
 
 def find_file_descend(filename: str, path: str | Path) -> Path | None:
@@ -150,3 +152,9 @@ def expand_grid(data: dict) -> list[dict]:
         dict(zip(data.keys(), el, strict=False))
         for el in product(*data.values())
     ]
+
+
+# Probably some more work here to get the name to str here?
+def read_csv_to_dict(filename: str | Path) -> list[dict[str, Any]]:
+    with Path(filename).open(newline="") as f:
+        return list(csv.DictReader(f))

--- a/tests/test_create_bulk.py
+++ b/tests/test_create_bulk.py
@@ -50,3 +50,18 @@ def test_can_raise_if_unexpected_symbols_in_data():
     pat = "Data variables not present in template: b"
     with pytest.raises(Exception, match=pat):
         bulk_create_shell_commands(cmd, pars)
+
+
+def test_can_raise_if_no_data():
+    cmd = ["cmd", "path/@{a}"]
+    with pytest.raises(Exception, match="No data provided"):
+        bulk_create_shell_commands(cmd, {})
+    with pytest.raises(Exception, match="No data provided"):
+        bulk_create_shell_commands(cmd, [])
+
+
+def test_can_raise_if_data_does_not_have_consistent_keys():
+    cmd = ["cmd", "path/@{a}", "@b"]
+    data = [{"a": "0", "b": "1"}, {"a": "0", "b": "1", "c": "2"}]
+    with pytest.raises(Exception, match="Inconsistent keys among data"):
+        bulk_create_shell_commands(cmd, data)

--- a/tests/test_create_bulk.py
+++ b/tests/test_create_bulk.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hipercow.task_create_bulk import (
     _bulk_data_combine,
     bulk_create_shell_commands,
@@ -32,3 +34,19 @@ def test_can_construct_templated_calls():
     res = bulk_create_shell_commands(cmd, data)
     assert res == [["cmd", "path/0", "2"], ["cmd", "path/1", "2"]]
     assert bulk_create_shell_commands(cmd, pars) == res
+
+
+def test_can_raise_if_unexpected_symbols_in_template():
+    cmd = ["cmd", "path/@{a}", "@b"]
+    pars = {"a": ["0", "1"]}
+    pat = "Template variables not present in data: b"
+    with pytest.raises(Exception, match=pat):
+        bulk_create_shell_commands(cmd, pars)
+
+
+def test_can_raise_if_unexpected_symbols_in_data():
+    cmd = ["cmd", "path/@{a}"]
+    pars = {"a": ["0", "1"], "b": ["2", "3"]}
+    pat = "Data variables not present in template: b"
+    with pytest.raises(Exception, match=pat):
+        bulk_create_shell_commands(cmd, pars)

--- a/tests/test_create_bulk.py
+++ b/tests/test_create_bulk.py
@@ -1,0 +1,32 @@
+from hipercow.task_create_bulk import (
+    _bulk_data_combine,
+    bulk_create_shell_commands,
+)
+
+
+def test_prepare_simple_grid():
+    assert _bulk_data_combine({"a": ["0", "1", "2"]}) == [
+        {"a": "0"},
+        {"a": "1"},
+        {"a": "2"},
+    ]
+    assert _bulk_data_combine({"a": ["0", "1", "2"], "b": "3"}) == [
+        {"a": "0", "b": "3"},
+        {"a": "1", "b": "3"},
+        {"a": "2", "b": "3"},
+    ]
+    assert _bulk_data_combine({"a": ["0", "1", "2"], "b": ["3", "4"]}) == [
+        {"a": "0", "b": "3"},
+        {"a": "0", "b": "4"},
+        {"a": "1", "b": "3"},
+        {"a": "1", "b": "4"},
+        {"a": "2", "b": "3"},
+        {"a": "2", "b": "4"},
+    ]
+
+
+def test_can_construct_templated_calls():
+    cmd = ["cmd", "path/@{a}", "@b"]
+    data = _bulk_data_combine({"a": ["0", "1"], "b": ["2"]})
+    res = bulk_create_shell_commands(cmd, data)
+    assert res == [["cmd", "path/0", "2"], ["cmd", "path/1", "2"]]

--- a/tests/test_create_bulk.py
+++ b/tests/test_create_bulk.py
@@ -27,6 +27,8 @@ def test_prepare_simple_grid():
 
 def test_can_construct_templated_calls():
     cmd = ["cmd", "path/@{a}", "@b"]
-    data = _bulk_data_combine({"a": ["0", "1"], "b": ["2"]})
+    pars = {"a": ["0", "1"], "b": ["2"]}
+    data = _bulk_data_combine(pars)
     res = bulk_create_shell_commands(cmd, data)
     assert res == [["cmd", "path/0", "2"], ["cmd", "path/1", "2"]]
+    assert bulk_create_shell_commands(cmd, pars) == res

--- a/tests/test_create_bulk.py
+++ b/tests/test_create_bulk.py
@@ -5,6 +5,8 @@ from hipercow.bundle import bundle_load
 from hipercow.task import task_info
 from hipercow.task_create_bulk import (
     _bulk_data_combine,
+    _template_identifiers,
+    _TemplateAt,
     bulk_create_shell,
     bulk_create_shell_commands,
 )
@@ -87,3 +89,8 @@ def test_can_bulk_create_tasks(tmp_path):
     assert d0.data.data["cmd"] == ["cowsay", "-c", "cow", "-t", "hello"]
     d1 = task_info(bundle.task_ids[1], root=r)
     assert d1.data.data["cmd"] == ["cowsay", "-c", "cow", "-t", "hipercow"]
+
+
+def test_can_extract_identrifiers_with_backport():
+    obj = _TemplateAt("hello @{a} @b world")
+    assert _template_identifiers(obj) == ["a", "b"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,6 +7,7 @@ import pytest
 
 from hipercow.util import (
     check_python_version,
+    expand_grid,
     find_file_descend,
     loop_while,
     subprocess_run,
@@ -117,3 +118,21 @@ def test_loop_while_loops():
     fn = mock.Mock(side_effect=[False, True, True, False, False])
     loop_while(fn)
     assert fn.call_count == 1
+
+
+def test_expand_grid():
+    assert expand_grid({}) == [{}]
+    assert expand_grid({"a": [1]}) == [{"a": 1}]
+    assert expand_grid({"a": [1, 2]}) == [{"a": 1}, {"a": 2}]
+    assert expand_grid({"a": [1, 2], "b": [3]}) == [
+        {"a": 1, "b": 3},
+        {"a": 2, "b": 3},
+    ]
+    assert expand_grid({"a": [1, 2], "b": [3, 4, 5]}) == [
+        {"a": 1, "b": 3},
+        {"a": 1, "b": 4},
+        {"a": 1, "b": 5},
+        {"a": 2, "b": 3},
+        {"a": 2, "b": 4},
+        {"a": 2, "b": 5},
+    ]


### PR DESCRIPTION
This does most of the heavy lifting for creating a group of related commands as a bundle, though not the wiring through to the cli interface which will follow.

The user submits a template command like

```
tlo run myscenario @run @replica --output path/@{run}/@{replica}
```

which contains `@` delimited template strings.  The braces are optional, as above. In the programmatic interface this would be submitted as a list of course but the idea is the same.  I've gone with `@` rather than `$` to avoid issues with shell quoting (and avoiding `%` for windows too.  The `@` symbol seems fairly shell safe and better than just about any other obvious character while remaining fairly easy to reason about.  This is implemented using python's simple `string.Template` class, though you have to subclass it to change the delimiter which is really odd, and it does not support introspection of variables until 3.11 so there's a workaround to support 3.11

The other half of the battle is the data to interpolate into this.  I've supported two modes:

* A list of dicts - we might expect this from reading a csv
* A dict of lists - we expand these (in R `expand.grid()` style) into a list of dicts containing all possible combinations

Then we loop over the list and create all the different substitutions.
