### PR TITLE
Avoid pickle for serialisation: the easy bits

### DIFF
--- a/src/hipercow/dide/mounts.py
+++ b/src/hipercow/dide/mounts.py
@@ -2,7 +2,6 @@ import csv
 import platform
 import re
 import subprocess
-from dataclasses import dataclass
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -32,8 +31,7 @@ class Mount(BaseModel):
     local: Path
 
 
-@dataclass
-class PathMap:
+class PathMap(BaseModel):
     """The mapping between a local path and one on a remote share."""
 
     path: Path
@@ -70,7 +68,7 @@ def remap_path(path: Path, mounts: list[Mount]) -> PathMap:
     else:
         remote = "V:"
 
-    return PathMap(path, mount, remote, relative_str)
+    return PathMap(path=path, mount=mount, remote=remote, relative=relative_str)
 
 
 def detect_mounts() -> list[Mount]:

--- a/src/hipercow/dide/mounts.py
+++ b/src/hipercow/dide/mounts.py
@@ -5,6 +5,8 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from pydantic import BaseModel
+
 
 # We use 'str' here and not 'Path' because we are interested in
 # storing paths that might be of a different type to the host
@@ -14,8 +16,7 @@ from pathlib import Path
 # different type than the host system, which means things like leading
 # and trailing slashes or forward slashes vs backslashes become hard
 # to reason about.
-@dataclass
-class Mount:
+class Mount(BaseModel):
     """The name of the host on which the mount is found."""
 
     host: str
@@ -102,7 +103,9 @@ def _parse_unix_mount_entry(x: str) -> Mount:
 
     _, host, remote, local, _ = m.groups()
 
-    return Mount(_clean_dide_hostname(host), remote, Path(local))
+    return Mount(
+        host=_clean_dide_hostname(host), remote=remote, local=Path(local)
+    )
 
 
 def _detect_mounts_windows() -> list[Mount]:
@@ -134,7 +137,9 @@ def _parse_windows_mount_entry(local: str, remote: str) -> Mount:
         msg = "Failed to parse windows entry"
         raise Exception(msg)
     host, remote = m.groups()
-    return Mount(_clean_dide_hostname(host), remote, Path(local + "/"))
+    return Mount(
+        host=_clean_dide_hostname(host), remote=remote, local=Path(local + "/")
+    )
 
 
 def _clean_dide_hostname(host: str) -> str:

--- a/src/hipercow/environment.py
+++ b/src/hipercow/environment.py
@@ -162,7 +162,7 @@ def environment_engine(name: str, root: Root) -> EnvironmentEngine:
     if use_empty_environment:
         cfg = EnvironmentConfiguration(engine="empty")
     else:
-        with root.path_environment_config(name).open("rb") as f:
+        with root.path_environment_config(name).open() as f:
             cfg = EnvironmentConfiguration.model_validate_json(f.read())
     if cfg.engine == "pip":
         return Pip(root, name)

--- a/src/hipercow/provision.py
+++ b/src/hipercow/provision.py
@@ -143,4 +143,4 @@ def _read_provisioning_record(
             result = ProvisioningResult.model_validate_json(f.read())
     except FileNotFoundError:
         result = None
-    return ProvisioningRecord(data = data, result = result)
+    return ProvisioningRecord(data=data, result=result)

--- a/src/hipercow/task.py
+++ b/src/hipercow/task.py
@@ -204,8 +204,7 @@ def task_data_read(task_id: str, root: Root) -> TaskData:
         return pickle.load(f)
 
 
-@dataclass
-class TaskInfo:
+class TaskInfo(BaseModel):
     status: TaskStatus
     data: TaskData
     times: TaskTimes
@@ -220,7 +219,7 @@ def task_info(task_id: str, root: OptionalRoot = None) -> TaskInfo:
         raise Exception(msg)
     data = TaskData.read(task_id, root)
     times = _read_task_times(task_id, root)
-    return TaskInfo(status, data, times)
+    return TaskInfo(status=status, data=data, times=times)
 
 
 def task_list(

--- a/src/hipercow/task_create.py
+++ b/src/hipercow/task_create.py
@@ -4,7 +4,7 @@ from hipercow.driver import load_driver_optional
 from hipercow.environment import environment_check
 from hipercow.resources import TaskResources
 from hipercow.root import OptionalRoot, Root, open_root
-from hipercow.task import TaskData, TaskStatus, set_task_status
+from hipercow.task import TaskData, TaskStatus, set_task_status, task_data_write
 from hipercow.util import relative_workdir
 
 
@@ -95,7 +95,7 @@ def _task_create(
         resources=resources,
         envvars=envvars,
     )
-    task_data.write(root)
+    task_data_write(task_data, root)
     with root.path_recent().open("a") as f:
         f.write(f"{task_id}\n")
     if dr:

--- a/src/hipercow/task_eval.py
+++ b/src/hipercow/task_eval.py
@@ -49,8 +49,9 @@ def task_eval_data(data: TaskData, *, capture: bool, root: Root) -> None:
     with root.path_task_result(task_id).open("wb") as f:
         pickle.dump(res.data, f)
 
-    times = TaskTimes(t_created, t_start, t_end)
-    times.write(task_id, root)
+    times = TaskTimes(created=t_created, started=t_start, finished=t_end)
+    with root.path_task_times(task_id).open("w") as f:
+        f.write(times.model_dump_json())
 
     set_task_status(task_id, status, None, root)
 

--- a/src/hipercow/task_eval.py
+++ b/src/hipercow/task_eval.py
@@ -9,6 +9,7 @@ from hipercow.task import (
     TaskStatus,
     TaskTimes,
     set_task_status,
+    task_data_read,
     task_status,
 )
 
@@ -24,7 +25,7 @@ def task_eval(
     task_id: str, *, capture: bool, root: OptionalRoot = None
 ) -> None:
     root = open_root(root)
-    data = TaskData.read(task_id, root)
+    data = task_data_read(task_id, root)
     task_eval_data(data, capture=capture, root=root)
 
 

--- a/tests/dide/test_batch.py
+++ b/tests/dide/test_batch.py
@@ -10,7 +10,7 @@ def test_can_create_batch_data(tmp_path):
     path = tmp_path / "my/project"
     root.init(path)
     r = root.open_root(path)
-    m = Mount("wpia-hn", "didehomes/bob", tmp_path)
+    m = Mount(host="wpia-hn", remote="didehomes/bob", local=tmp_path)
     config = DideConfiguration(
         r, mounts=[m], python_version=None, check_credentials=False
     )
@@ -31,7 +31,7 @@ def test_can_write_batch(tmp_path):
     path = tmp_path / "my/project"
     root.init(path)
     r = root.open_root(path)
-    m = Mount("wpia-hn", "didehomes/bob", tmp_path)
+    m = Mount(host="wpia-hn", remote="didehomes/bob", local=tmp_path)
     config = DideConfiguration(
         r, mounts=[m], python_version=None, check_credentials=False
     )
@@ -49,7 +49,7 @@ def test_can_create_provision_data(tmp_path):
     path = tmp_path / "my/project"
     root.init(path)
     r = root.open_root(path)
-    m = Mount("wpia-hn", "didehomes/bob", tmp_path)
+    m = Mount(host="wpia-hn", remote="didehomes/bob", local=tmp_path)
     config = DideConfiguration(
         r, mounts=[m], python_version=None, check_credentials=False
     )
@@ -69,7 +69,7 @@ def test_can_write_provision_batch(tmp_path):
     path = tmp_path / "my/project"
     root.init(path)
     r = root.open_root(path)
-    m = Mount("wpia-hn", "didehomes/bob", tmp_path)
+    m = Mount(host="wpia-hn", remote="didehomes/bob", local=tmp_path)
     config = DideConfiguration(
         r, mounts=[m], python_version=None, check_credentials=False
     )

--- a/tests/dide/test_configure.py
+++ b/tests/dide/test_configure.py
@@ -18,7 +18,7 @@ def test_can_configure_dide_mount(tmp_path, mocker):
     path = tmp_path / "a" / "b"
     root.init(path)
     r = root.open_root(path)
-    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mock_mounts = [Mount(host="projects", remote="other", local=tmp_path)]
     mock_check_auth = mock.Mock()
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
     mocker.patch("hipercow.dide.configuration.check_auth", mock_check_auth)
@@ -38,7 +38,7 @@ def test_creating_task_triggers_submission(tmp_path, mocker):
     path = tmp_path / "a" / "b"
     root.init(path)
     r = root.open_root(path)
-    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mock_mounts = [Mount(host="projects", remote="other", local=tmp_path)]
     mock_creds = Credentials("bob", "secret")
     mock_web_client = mock.MagicMock(spec=DideWebClient)
 
@@ -69,7 +69,7 @@ def test_creating_task_with_resources(tmp_path, mocker):
     path = tmp_path / "a" / "b"
     root.init(path)
     r = root.open_root(path)
-    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mock_mounts = [Mount(host="projects", remote="other", local=tmp_path)]
     mock_creds = Credentials("bob", "secret")
     mock_web_client = mock.MagicMock(spec=DideWebClient)
 
@@ -104,7 +104,7 @@ def test_provision_using_driver(tmp_path, mocker):
     path = tmp_path / "a" / "b"
     root.init(path)
     r = root.open_root(path)
-    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mock_mounts = [Mount(host="projects", remote="other", local=tmp_path)]
     mock_provision = mock.MagicMock()
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
     mocker.patch("hipercow.dide.driver._dide_provision", mock_provision)
@@ -125,7 +125,7 @@ def test_resources_using_driver(tmp_path, mocker):
     path = tmp_path / "a" / "b"
     root.init(path)
     r = root.open_root(path)
-    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mock_mounts = [Mount(host="projects", remote="other", local=tmp_path)]
     mock_provision = mock.MagicMock()
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
     mocker.patch("hipercow.dide.driver._dide_provision", mock_provision)
@@ -143,7 +143,7 @@ def test_configure_python_version(tmp_path, mocker, capsys):
     path = tmp_path / "a" / "b"
     root.init(path)
     r = root.open_root(path)
-    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mock_mounts = [Mount(host="projects", remote="other", local=tmp_path)]
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)
     configure(
         "dide-windows", python_version="3.12", check_credentials=False, root=r
@@ -158,7 +158,7 @@ def test_get_outer_logs_from_web_client(tmp_path, mocker):
     path = tmp_path / "a" / "b"
     root.init(path)
     r = root.open_root(path)
-    mock_mounts = [Mount("projects", "other", tmp_path)]
+    mock_mounts = [Mount(host="projects", remote="other", local=tmp_path)]
     mock_creds = Credentials("bob", "secret")
     mock_web_client = mock.MagicMock(spec=DideWebClient)
     mocker.patch("hipercow.dide.driver.detect_mounts", return_value=mock_mounts)

--- a/tests/dide/test_mounts.py
+++ b/tests/dide/test_mounts.py
@@ -11,7 +11,9 @@ def test_can_parse_cifs_output():
     m = mounts._parse_unix_mount_entry(
         "//projects/other on /path/local type cifs (rw,relatime)"
     )
-    assert m == mounts.Mount("projects", "other", Path("/path/local"))
+    assert m == mounts.Mount(
+        host="projects", remote="other", local=Path("/path/local")
+    )
 
 
 def test_can_parse_mounts_on_unix(mocker):
@@ -22,8 +24,12 @@ def test_can_parse_mounts_on_unix(mocker):
     mocker.patch("subprocess.run", return_value=response)
     res = mounts._detect_mounts_unix("Linux")
     assert len(res) == 2
-    assert res[0] == mounts.Mount("projects", "other", Path("/path/local"))
-    assert res[1] == mounts.Mount("projects", "other2", Path("/path/local2"))
+    assert res[0] == mounts.Mount(
+        host="projects", remote="other", local=Path("/path/local")
+    )
+    assert res[1] == mounts.Mount(
+        host="projects", remote="other2", local=Path("/path/local2")
+    )
 
 
 def test_can_clean_dide_hostname():
@@ -43,8 +49,12 @@ def test_can_parse_mounts_on_windows(mocker):
     mocker.patch("subprocess.run", return_value=response)
     res = mounts._detect_mounts_windows()
     assert len(res) == 2
-    assert res[0] == mounts.Mount("wpia-hn", "hipercow", Path("I:/"))
-    assert res[1] == mounts.Mount("wpia-hn2.hpc", "Climate", Path("Y:/"))
+    assert res[0] == mounts.Mount(
+        host="wpia-hn", remote="hipercow", local=Path("I:/")
+    )
+    assert res[1] == mounts.Mount(
+        host="wpia-hn2.hpc", remote="Climate", local=Path("Y:/")
+    )
 
 
 def test_can_get_correct_smb_type():
@@ -58,7 +68,7 @@ def test_throw_on_remap_with_no_mounts():
 
 
 def test_can_remap_path():
-    m = [mounts.Mount("host", "/hostmount", Path("/local"))]
+    m = [mounts.Mount(host="host", remote="/hostmount", local=Path("/local"))]
     path = Path("/local/path/to/dir")
     res = mounts.remap_path(path, m)
     assert res == mounts.PathMap(path, m[0], "V:", relative="path/to/dir")
@@ -66,8 +76,8 @@ def test_can_remap_path():
 
 def test_throw_if_two_plausible_mounts():
     m = [
-        mounts.Mount("host1", "/path1", Path("/local/path")),
-        mounts.Mount("host2", "/path2", Path("/local")),
+        mounts.Mount(host="host1", remote="/path1", local=Path("/local/path")),
+        mounts.Mount(host="host2", remote="/path2", local=Path("/local")),
     ]
     path = Path("/local/path/to/dir")
     with pytest.raises(Exception, match="More than one plausible"):
@@ -75,14 +85,14 @@ def test_throw_if_two_plausible_mounts():
 
 
 def test_preserve_drive_letter_if_given():
-    m = [mounts.Mount("host", "/hostmount", Path("P:/"))]
+    m = [mounts.Mount(host="host", remote="/hostmount", local=Path("P:/"))]
     path = Path("P:/local/path")
     res = mounts.remap_path(path, m)
     assert res == mounts.PathMap(path, m[0], "P:", relative="local/path")
 
 
 def test_can_map_home_to_q_drive():
-    m = [mounts.Mount("qdrive", "user", Path("/local"))]
+    m = [mounts.Mount(host="qdrive", remote="user", local=Path("/local"))]
     path = Path("/local/path/to/dir")
     res = mounts.remap_path(path, m)
     assert res == mounts.PathMap(path, m[0], "Q:", relative="path/to/dir")
@@ -92,7 +102,9 @@ def test_can_parse_unix_entry():
     res = mounts._parse_unix_mount_entry(
         "//projects.dide.ic.ac.uk/other on /path/local type cifs (rw,relatime)"
     )
-    assert res == mounts.Mount("projects", "other", Path("/path/local"))
+    assert res == mounts.Mount(
+        host="projects", remote="other", local=Path("/path/local")
+    )
 
 
 def test_throw_if_error_in_unix_mount_entry():
@@ -104,7 +116,9 @@ def test_can_parse_windows_mount_point():
     res = mounts._parse_windows_mount_entry(
         "E:", "//projects.dide.ic.ac.uk/other"
     )
-    assert res == mounts.Mount("projects", "other", Path("E:/"))
+    assert res == mounts.Mount(
+        host="projects", remote="other", local=Path("E:/")
+    )
 
 
 def test_throw_if_error_in_windows_mount_point():

--- a/tests/dide/test_mounts.py
+++ b/tests/dide/test_mounts.py
@@ -71,7 +71,9 @@ def test_can_remap_path():
     m = [mounts.Mount(host="host", remote="/hostmount", local=Path("/local"))]
     path = Path("/local/path/to/dir")
     res = mounts.remap_path(path, m)
-    assert res == mounts.PathMap(path, m[0], "V:", relative="path/to/dir")
+    assert res == mounts.PathMap(
+        path=path, mount=m[0], remote="V:", relative="path/to/dir"
+    )
 
 
 def test_throw_if_two_plausible_mounts():
@@ -88,14 +90,18 @@ def test_preserve_drive_letter_if_given():
     m = [mounts.Mount(host="host", remote="/hostmount", local=Path("P:/"))]
     path = Path("P:/local/path")
     res = mounts.remap_path(path, m)
-    assert res == mounts.PathMap(path, m[0], "P:", relative="local/path")
+    assert res == mounts.PathMap(
+        path=path, mount=m[0], remote="P:", relative="local/path"
+    )
 
 
 def test_can_map_home_to_q_drive():
     m = [mounts.Mount(host="qdrive", remote="user", local=Path("/local"))]
     path = Path("/local/path/to/dir")
     res = mounts.remap_path(path, m)
-    assert res == mounts.PathMap(path, m[0], "Q:", relative="path/to/dir")
+    assert res == mounts.PathMap(
+        path=path, mount=m[0], remote="Q:", relative="path/to/dir"
+    )
 
 
 def test_can_parse_unix_entry():

--- a/tests/dide/test_provision.py
+++ b/tests/dide/test_provision.py
@@ -21,7 +21,7 @@ def test_can_provision_with_dide(tmp_path, mocker):
     with (r.path / "requirements.txt").open("w") as f:
         f.write("cowsay\n")
 
-    m = mounts.Mount("host", "hostmount", Path("/local"))
+    m = mounts.Mount(host="host", remote="hostmount", local=Path("/local"))
     path_map = mounts.PathMap(tmp_path, m, "Q:", relative="path/to/dir")
 
     mock_client = mock.MagicMock(spec=DideWebClient)
@@ -83,7 +83,7 @@ def test_throw_after_failed_provision_with_dide(tmp_path, mocker, capsys):
     with (r.path / "requirements.txt").open("w") as f:
         f.write("cowsay\n")
 
-    m = mounts.Mount("host", "hostmount", Path("/local"))
+    m = mounts.Mount(host="host", remote="hostmount", local=Path("/local"))
     path_map = mounts.PathMap(tmp_path, m, "Q:", relative="path/to/dir")
 
     mock_client = mock.MagicMock(spec=DideWebClient)

--- a/tests/dide/test_provision.py
+++ b/tests/dide/test_provision.py
@@ -22,7 +22,9 @@ def test_can_provision_with_dide(tmp_path, mocker):
         f.write("cowsay\n")
 
     m = mounts.Mount(host="host", remote="hostmount", local=Path("/local"))
-    path_map = mounts.PathMap(tmp_path, m, "Q:", relative="path/to/dir")
+    path_map = mounts.PathMap(
+        path=tmp_path, mount=m, remote="Q:", relative="path/to/dir"
+    )
 
     mock_client = mock.MagicMock(spec=DideWebClient)
     mocker.patch("hipercow.dide.driver._web_client", return_value=mock_client)
@@ -84,7 +86,9 @@ def test_throw_after_failed_provision_with_dide(tmp_path, mocker, capsys):
         f.write("cowsay\n")
 
     m = mounts.Mount(host="host", remote="hostmount", local=Path("/local"))
-    path_map = mounts.PathMap(tmp_path, m, "Q:", relative="path/to/dir")
+    path_map = mounts.PathMap(
+        path=tmp_path, mount=m, remote="Q:", relative="path/to/dir"
+    )
 
     mock_client = mock.MagicMock(spec=DideWebClient)
     mock_client.log.return_value = "more logs"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from hipercow import cli, root, task
 from hipercow.bundle import bundle_load
 from hipercow.driver import list_drivers
 from hipercow.resources import TaskResources
-from hipercow.task import TaskData, TaskStatus, set_task_status
+from hipercow.task import TaskStatus, set_task_status, task_data_read
 from hipercow.task_create import task_create_shell
 from hipercow.util import transient_envvars
 from tests.helpers import AnyInstanceOf
@@ -216,7 +216,7 @@ def test_can_create_task_in_environment(tmp_path):
         )
         assert res.exit_code == 0
         task_id = res.stdout.strip()
-        data = TaskData.read(task_id, r)
+        data = task_data_read(task_id, r)
         assert data.environment == "other"
 
 
@@ -562,7 +562,7 @@ def test_can_control_queue_used_in_task_creation(tmp_path):
         )
         assert res.exit_code == 0
         task_id = res.stdout.splitlines()[1]
-        data = TaskData.read(task_id, r)
+        data = task_data_read(task_id, r)
         assert data.resources == TaskResources(queue="default")
 
         res = runner.invoke(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -6,7 +6,7 @@ from hipercow import root
 from hipercow import task_create as tc
 from hipercow.configure import configure
 from hipercow.resources import TaskResources
-from hipercow.task import TaskData, TaskStatus, task_status
+from hipercow.task import TaskData, TaskStatus, task_data_read, task_status
 from hipercow.util import transient_working_directory
 
 
@@ -20,7 +20,7 @@ def test_create_simple_task(tmp_path):
         tmp_path / "hipercow" / "py" / "tasks" / tid[:2] / tid[2:] / "data"
     )
     assert path_data.exists()
-    d = TaskData.read(tid, root.open_root(tmp_path))
+    d = task_data_read(tid, root.open_root(tmp_path))
     assert isinstance(d, TaskData)
     assert d.task_id == tid
     assert d.method == "shell"
@@ -84,5 +84,5 @@ def test_can_save_resources_on_submission(tmp_path):
         tid = tc.task_create_shell(
             ["echo", "hello world"], resources=resources, root=r
         )
-    d = TaskData.read(tid, root.open_root(tmp_path))
+    d = task_data_read(tid, root.open_root(tmp_path))
     assert d.resources == TaskResources(queue="default", memory_per_task=1)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -19,7 +19,8 @@ def test_create_pip_environment(tmp_path):
     assert environment_list(r) == ["default", "empty"]
     with pytest.raises(Exception, match="'default' already exists"):
         environment_new("default", "pip", r)
-    cfg = EnvironmentConfiguration.read("default", r)
+    with r.path_environment_config("default").open() as f:
+        cfg = EnvironmentConfiguration.model_validate_json(f.read())
     assert cfg.engine == "pip"
 
 

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -106,7 +106,7 @@ def test_record_provisioning_error(tmp_path, mocker):
 
     h = provision_history("default", r)
     assert len(h) == 1
-    assert isinstance(h[0].result.error, Exception)
+    assert h[0].result.error == "some ghastly error"
 
 
 def test_throw_on_provision_if_no_environment(tmp_path):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -6,13 +6,13 @@ import pytest
 from hipercow import root
 from hipercow import task_create as tc
 from hipercow.task import (
-    TaskData,
     TaskStatus,
     TaskWaitWrapper,
     _read_task_times,
     check_task_id,
     is_valid_task_id,
     set_task_status,
+    task_data_read,
     task_driver,
     task_exists,
     task_info,
@@ -78,7 +78,7 @@ def test_read_task_info(tmp_path):
         tid = tc.task_create_shell(["echo", "hello world"], root=r)
     info = task_info(tid, r)
     assert info.status == TaskStatus.CREATED
-    assert info.data == TaskData.read(tid, r)
+    assert info.data == task_data_read(tid, r)
     assert info.times == _read_task_times(tid, r)
     assert isinstance(info.times.created, float)
     assert info.times.started is None
@@ -101,7 +101,7 @@ def test_that_can_read_info_for_completed_task(tmp_path):
         task_eval(tid, capture=False, root=r)
         info = task_info(tid, r)
     assert info.status == TaskStatus.SUCCESS
-    assert info.data == TaskData.read(tid, r)
+    assert info.data == task_data_read(tid, r)
     assert info.times == _read_task_times(tid, r)
     assert isinstance(info.times.created, float)
     assert isinstance(info.times.started, float)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -8,8 +8,8 @@ from hipercow import task_create as tc
 from hipercow.task import (
     TaskData,
     TaskStatus,
-    TaskTimes,
     TaskWaitWrapper,
+    _read_task_times,
     check_task_id,
     is_valid_task_id,
     set_task_status,
@@ -79,7 +79,7 @@ def test_read_task_info(tmp_path):
     info = task_info(tid, r)
     assert info.status == TaskStatus.CREATED
     assert info.data == TaskData.read(tid, r)
-    assert info.times == TaskTimes.read(tid, r)
+    assert info.times == _read_task_times(tid, r)
     assert isinstance(info.times.created, float)
     assert info.times.started is None
     assert info.times.finished is None
@@ -102,7 +102,7 @@ def test_that_can_read_info_for_completed_task(tmp_path):
         info = task_info(tid, r)
     assert info.status == TaskStatus.SUCCESS
     assert info.data == TaskData.read(tid, r)
-    assert info.times == TaskTimes.read(tid, r)
+    assert info.times == _read_task_times(tid, r)
     assert isinstance(info.times.created, float)
     assert isinstance(info.times.started, float)
     assert isinstance(info.times.finished, float)


### PR DESCRIPTION
There are three places where we use pickle;

* saving the output of tasks - this is possibly unavoidable as we are super general at this point and is the hardest
* saving driver configuration - this is the most important to fix but requires some degree of refactoring to separate out driver configuration from driver loading and avoiding some circular dependencies - I'll do this next so that it is easier to follow
* everywhere else where a bit of data gets saved to disk

This PR does the latter, which is mostly a case of swapping out dataclass+pickle for pydanic + json serialisation. We could look at other serialisation libraries (msgspec looks good) but a subsequent change would be fairly straightforward.